### PR TITLE
CON-6 Detect IP Address automatically

### DIFF
--- a/src/main/java/com/adieser/conntest/controllers/ConnTestController.java
+++ b/src/main/java/com/adieser/conntest/controllers/ConnTestController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
 
 @RestController
@@ -27,10 +26,7 @@ public class ConnTestController {
 
     @PostMapping("/test-local-isp-cloud")
     public void testLocalIspCloud() {
-
-        connTestService.testLocalISPInternet(
-                Arrays.asList("192.168.1.1", "131.100.65.1", "8.8.8.8")
-        );
+        connTestService.testLocalISPInternet();
     }
 
     @PostMapping("/stop-tests")

--- a/src/main/java/com/adieser/conntest/models/PingLogRepository.java
+++ b/src/main/java/com/adieser/conntest/models/PingLogRepository.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Repository;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.OptionalDouble;
 
 @Repository
 public interface PingLogRepository {

--- a/src/main/java/com/adieser/conntest/service/ConnTestService.java
+++ b/src/main/java/com/adieser/conntest/service/ConnTestService.java
@@ -5,10 +5,9 @@ import com.adieser.conntest.controllers.responses.PingLogFile;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.OptionalDouble;
 
 public interface ConnTestService {
-    void testLocalISPInternet(List<String> ipAddresses);
+    void testLocalISPInternet();
     void stopTests();
     List<PingLogFile> getPings();
     List<PingLogFile> getPingsByIp(String ipAddress);


### PR DESCRIPTION
A trace route feature was implemented for windows. tracert tool is invoked: `tracert -h 2 8.8.8.8`
This tool is used for discovering local IP and ISP IP (second hop in the trace)