### PR TITLE
CON-7 Implement idempotency in the API

### DIFF
--- a/src/main/java/com/adieser/conntest/service/ConnTestServiceImpl.java
+++ b/src/main/java/com/adieser/conntest/service/ConnTestServiceImpl.java
@@ -51,13 +51,15 @@ public class ConnTestServiceImpl implements ConnTestService {
 
     @Override
     public void testLocalISPInternet(){
+        if(tests.isEmpty()){
+            List<String> ipAddresses = getLocalAndISPIpAddresses();
+            ipAddresses.add(CLOUD_IP);
 
-        List<String> ipAddresses = getLocalAndISPIpAddresses();
-        ipAddresses.add(CLOUD_IP);
+            tests = getConnTestsFromIpAddresses(ipAddresses);
 
-        tests = getConnTestsFromIpAddresses(ipAddresses);
-
-        tests.forEach(Pingable::startPingSession);
+            tests.forEach(Pingable::startPingSession);
+        }else
+            logger.warn("Tests are already running");
     }
 
     @Override


### PR DESCRIPTION
## Overview
There are only two POST endpoints that have to be idempotent, but only one of them is currently not: `/test-local-isp-cloud`

## Changes
- add idempotency to endpoint /test-local-isp-cloud
- add test scenarios