### PR TITLE
CON-8 Implement HATEOAS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,18 +44,13 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>com.opencsv</groupId>
 			<artifactId>opencsv</artifactId>
 			<version>5.8</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-hateoas</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/adieser/conntest/ConntestApplication.java
+++ b/src/main/java/com/adieser/conntest/ConntestApplication.java
@@ -1,8 +1,10 @@
 package com.adieser.conntest;
 
+import com.adieser.conntest.utils.NotIncludeInCodeCoverageGenerated;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+@NotIncludeInCodeCoverageGenerated
 @SpringBootApplication
 public class ConntestApplication {
 

--- a/src/main/java/com/adieser/conntest/controllers/ConnTestController.java
+++ b/src/main/java/com/adieser/conntest/controllers/ConnTestController.java
@@ -1,8 +1,10 @@
 package com.adieser.conntest.controllers;
 
 import com.adieser.conntest.controllers.responses.AverageResponse;
-import com.adieser.conntest.controllers.responses.PingSessionResponseEntity;
+import com.adieser.conntest.controllers.responses.PingSessionExtract;
+import com.adieser.conntest.controllers.responses.PingTestResponse;
 import com.adieser.conntest.service.ConnTestService;
+import com.adieser.conntest.utils.HATEOASLinkRelValueTemplates;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,10 +14,17 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
-import java.util.List;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 /**
  * Controller to interact with pings
+ */
+
+/*
+    produces={"application/json"} is used in some endpoints to avoid the HATEOAS
+    default content-type: application/hal+json in the responses
  */
 @RestController
 public class ConnTestController {
@@ -29,17 +38,29 @@ public class ConnTestController {
     /**
      * Trigger 3 ping sessions to test connection against local gateway, the next hop, and the cloud (Google's 8.8.8.8)
      */
-    @PostMapping("/test-local-isp-cloud")
-    public void testLocalIspCloud() {
+    @PostMapping(value = "/test-local-isp-cloud", produces = {"application/json"})
+    public ResponseEntity<PingTestResponse> testLocalIspCloud() {
         connTestService.testLocalISPInternet();
+
+        PingTestResponse response = new PingTestResponse();
+        response.add(linkTo(methodOn(ConnTestController.class).stopTests())
+                .withRel(HATEOASLinkRelValueTemplates.STOP_TEST_SESSION));
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     /**
      * stop all the test sessions
      */
-    @PostMapping("/stop-tests")
-    public void stopTests() {
+    @PostMapping(value = "/stop-tests", produces={"application/json"})
+    public ResponseEntity<PingTestResponse> stopTests() {
         connTestService.stopTests();
+
+        PingTestResponse response = new PingTestResponse();
+        response.add(linkTo(methodOn(ConnTestController.class).testLocalIspCloud())
+                .withRel(HATEOASLinkRelValueTemplates.START_TEST_SESSION));
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     /**
@@ -47,12 +68,14 @@ public class ConnTestController {
      * @return If successful it returns a list of pings along with the total count
      */
     @GetMapping("/pings")
-    public ResponseEntity<List<PingSessionResponseEntity>> getPings() {
+    public ResponseEntity<PingSessionExtract> getPings() {
         HttpStatus httpStatus = HttpStatus.OK;
-        List<PingSessionResponseEntity> pings = connTestService.getPings();
+        PingSessionExtract pings = connTestService.getPings();
 
-        if(pings.isEmpty())
+        if(pings.getPingLogs().isEmpty())
             httpStatus = HttpStatus.NO_CONTENT;
+
+        addHATEOASLinksForPingLogsReturningEndpoints(pings);
 
         return new ResponseEntity<>(pings, httpStatus);
     }
@@ -64,14 +87,16 @@ public class ConnTestController {
      * @return If successful it returns a list of pings along with the total count
      */
     @GetMapping("/pings/{start}/{end}")
-    public ResponseEntity<List<PingSessionResponseEntity>> getPingsByDateTimeRange(
+    public ResponseEntity<PingSessionExtract> getPingsByDateTimeRange(
             @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime start,
             @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime end) {
         HttpStatus httpStatus = HttpStatus.OK;
-        List<PingSessionResponseEntity> pings = connTestService.getPingsByDateTimeRange(start, end);
+        PingSessionExtract pings = connTestService.getPingsByDateTimeRange(start, end);
 
-        if(pings.isEmpty())
+        if(pings.getPingLogs().isEmpty())
             httpStatus = HttpStatus.NO_CONTENT;
+
+        addHATEOASLinksForPingLogsReturningEndpoints(pings);
 
         return new ResponseEntity<>(pings, httpStatus);
     }
@@ -82,12 +107,14 @@ public class ConnTestController {
      * @return If successful it returns a list of pings along with the total count
      */
     @GetMapping("/pings/{ipAddress}")
-    public ResponseEntity<List<PingSessionResponseEntity>> getPingsByIp(@PathVariable String ipAddress) {
+    public ResponseEntity<PingSessionExtract> getPingsByIp(@PathVariable String ipAddress) {
         HttpStatus httpStatus = HttpStatus.OK;
-        List<PingSessionResponseEntity> pings = connTestService.getPingsByIp(ipAddress);
+        PingSessionExtract pings = connTestService.getPingsByIp(ipAddress);
 
-        if(pings.isEmpty())
+        if(pings.getPingLogs().isEmpty())
             httpStatus = HttpStatus.NO_CONTENT;
+
+        addHATEOASLinksForPingLogsReturningEndpoints(pings);
 
         return new ResponseEntity<>(pings, httpStatus);
     }
@@ -100,15 +127,17 @@ public class ConnTestController {
      * @return If successful it returns a list of pings along with the total count
      */
     @GetMapping("/pings/{ipAddress}/{start}/{end}")
-    public ResponseEntity<List<PingSessionResponseEntity>> getPingsByDateTimeRangeByIp(
+    public ResponseEntity<PingSessionExtract> getPingsByDateTimeRangeByIp(
             @PathVariable String ipAddress,
             @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime start,
             @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime end) {
         HttpStatus httpStatus = HttpStatus.OK;
-        List<PingSessionResponseEntity> pings = connTestService.getPingsByDateTimeRangeByIp(start, end, ipAddress);
+        PingSessionExtract pings = connTestService.getPingsByDateTimeRangeByIp(start, end, ipAddress);
 
-        if(pings.isEmpty())
+        if(pings.getPingLogs().isEmpty())
             httpStatus = HttpStatus.NO_CONTENT;
+
+        addHATEOASLinksForPingLogsReturningEndpoints(pings);
 
         return new ResponseEntity<>(pings, httpStatus);
     }
@@ -118,13 +147,21 @@ public class ConnTestController {
      * @param ipAddress IP address used to filter the results
      * @return If successful it returns a number representing the average of lost pings
      */
-    @GetMapping("/pings/{ipAddress}/avg")
+    @GetMapping(value = "/pings/{ipAddress}/avg", produces = {"application/json"})
     public ResponseEntity<AverageResponse> getPingsLostAvgByIp(@PathVariable String ipAddress) {
 
+        AverageResponse averageResult = AverageResponse.builder()
+                .ipAddress(ipAddress)
+                .average(connTestService.getPingsLostAvgByIp(ipAddress))
+                .build();
+
+        averageResult.add(
+                linkTo(methodOn(ConnTestController.class).getPingsByIp(ipAddress))
+                        .withRel(HATEOASLinkRelValueTemplates.GET_BY_IP.formatted(ipAddress))
+        );
+
         return new ResponseEntity<>(
-                new AverageResponse(
-                        connTestService.getPingsLostAvgByIp(ipAddress)
-                ),
+                averageResult,
                 HttpStatus.OK
         );
     }
@@ -136,17 +173,46 @@ public class ConnTestController {
      * @param end End date in the range
      * @return If successful it returns a number representing the average of lost pings
      */
-    @GetMapping("/pings/{ipAddress}/avg/{start}/{end}")
+    @GetMapping(value = "/pings/{ipAddress}/avg/{start}/{end}", produces = {"application/json"})
     public ResponseEntity<AverageResponse> getPingsLostAvgByDateTimeRangeByIp(
             @PathVariable String ipAddress,
             @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime start,
             @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime end) {
 
+        AverageResponse averageResult = AverageResponse.builder()
+                .ipAddress(ipAddress)
+                .average(connTestService.getPingsLostAvgByDateTimeRangeByIp(start, end, ipAddress))
+                .build();
+
+        averageResult.add(
+                linkTo(methodOn(ConnTestController.class).getPingsByDateTimeRangeByIp(ipAddress, start, end))
+                        .withRel(HATEOASLinkRelValueTemplates.GET_30_MINS_NEIGHBORHOOD_BY_IP.formatted(ipAddress))
+        );
+
         return new ResponseEntity<>(
-                new AverageResponse(
-                        connTestService.getPingsLostAvgByDateTimeRangeByIp(start, end, ipAddress)
-                ),
+                averageResult,
                 HttpStatus.OK
         );
+    }
+
+    private static void addHATEOASLinksForPingLogsReturningEndpoints(PingSessionExtract pings) {
+        pings.getPingLogs().forEach(ping -> {
+            LocalDateTime floor = ping.getDateTime().minusMinutes(30);
+            LocalDateTime roof = ping.getDateTime().plusMinutes(30);
+            String ipAddress = ping.getIpAddress();
+
+            ping.add(
+                    linkTo(methodOn(ConnTestController.class).getPingsByIp(ipAddress))
+                            .withRel(HATEOASLinkRelValueTemplates.GET_BY_IP.formatted(ipAddress)),
+                    linkTo(methodOn(ConnTestController.class).getPingsByDateTimeRange(floor, roof))
+                            .withRel(HATEOASLinkRelValueTemplates.GET_30_MINS_NEIGHBORHOOD),
+                    linkTo(methodOn(ConnTestController.class).getPingsByDateTimeRangeByIp(ipAddress, floor, roof))
+                            .withRel(HATEOASLinkRelValueTemplates.GET_30_MINS_NEIGHBORHOOD_BY_IP.formatted(ipAddress)),
+                    linkTo(methodOn(ConnTestController.class).getPingsLostAvgByIp(ping.getIpAddress()))
+                            .withRel(HATEOASLinkRelValueTemplates.GET_LOST_AVG_BY_IP.formatted(ipAddress)),
+                    linkTo(methodOn(ConnTestController.class).getPingsLostAvgByDateTimeRangeByIp(ipAddress, floor, roof))
+                            .withRel(HATEOASLinkRelValueTemplates.GET_30_MINS_NEIGHBORHOOD_LOST_AVG_BY_IP.formatted(ipAddress))
+            );
+        });
     }
 }

--- a/src/main/java/com/adieser/conntest/controllers/responses/AverageResponse.java
+++ b/src/main/java/com/adieser/conntest/controllers/responses/AverageResponse.java
@@ -1,15 +1,46 @@
 package com.adieser.conntest.controllers.responses;
 
-import lombok.AllArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 import lombok.Getter;
+import org.springframework.hateoas.RepresentationModel;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 /**
  * Class to hold the result of average of lost pings
  */
 @Getter
-@AllArgsConstructor
-public class AverageResponse {
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AverageResponse extends RepresentationModel<AverageResponse> {
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private String ipAddress;
     private BigDecimal average;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) return false;
+        if (o == this) return true;
+        if (o.getClass() != getClass()) return false;
+
+        AverageResponse that = (AverageResponse) o;
+
+        return super.equals(o) &&
+                this.startDate.equals(that.startDate) &&
+                this.endDate.equals(that.endDate) &&
+                this.ipAddress.equals(that.ipAddress) &&
+                this.average.equals(that.average);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() +
+                this.startDate.hashCode() +
+                this.endDate.hashCode() +
+                this.ipAddress.hashCode() +
+                this.average.hashCode();
+    }
 }

--- a/src/main/java/com/adieser/conntest/controllers/responses/PingSessionExtract.java
+++ b/src/main/java/com/adieser/conntest/controllers/responses/PingSessionExtract.java
@@ -1,9 +1,11 @@
 package com.adieser.conntest.controllers.responses;
 
 import com.adieser.conntest.models.PingLog;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Data;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -11,7 +13,11 @@ import java.util.List;
  */
 @Data
 @Builder
-public class PingSessionResponseEntity {
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PingSessionExtract {
     private long amountOfPings;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private String ipAddress;
     private List<PingLog> pingLogs;
 }

--- a/src/main/java/com/adieser/conntest/controllers/responses/PingTestResponse.java
+++ b/src/main/java/com/adieser/conntest/controllers/responses/PingTestResponse.java
@@ -1,0 +1,6 @@
+package com.adieser.conntest.controllers.responses;
+
+import org.springframework.hateoas.RepresentationModel;
+
+public class PingTestResponse extends RepresentationModel<PingTestResponse> {
+}

--- a/src/main/java/com/adieser/conntest/models/PingLog.java
+++ b/src/main/java/com/adieser/conntest/models/PingLog.java
@@ -6,8 +6,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.hateoas.RepresentationModel;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 /**
  * Data structure to represent a Ping
@@ -16,7 +18,7 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class PingLog {
+public class PingLog extends RepresentationModel<PingLog> {
 
     /**
      * log datetime
@@ -36,4 +38,17 @@ public class PingLog {
      */
     @CsvBindByPosition(position = 2)
     private long pingTime;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PingLog pingLog)) return false;
+        if (!super.equals(o)) return false;
+        return pingTime == pingLog.pingTime && Objects.equals(dateTime, pingLog.dateTime) && Objects.equals(ipAddress, pingLog.ipAddress);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), dateTime, ipAddress, pingTime);
+    }
 }

--- a/src/main/java/com/adieser/conntest/service/ConnTestService.java
+++ b/src/main/java/com/adieser/conntest/service/ConnTestService.java
@@ -1,10 +1,9 @@
 package com.adieser.conntest.service;
 
-import com.adieser.conntest.controllers.responses.PingSessionResponseEntity;
+import com.adieser.conntest.controllers.responses.PingSessionExtract;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.List;
 
 /**
  * Service for testing connections in parallel based on a ping tool
@@ -22,33 +21,33 @@ public interface ConnTestService {
 
     /**
      * Retrieve all the ping logs
-     * @return List of ping results
+     * @return List of ping results and metadata {@link PingSessionExtract}
      */
-    List<PingSessionResponseEntity> getPings();
+    PingSessionExtract getPings();
 
     /**
      * Retrieve all the ping logs within a datetime range
      * @param start start date and time of the range
      * @param end end date in the range
-     * @return List of ping results
+     * @return List of ping results and metadata {@link PingSessionExtract}
      */
-    List<PingSessionResponseEntity> getPingsByDateTimeRange(LocalDateTime start, LocalDateTime end);
+    PingSessionExtract getPingsByDateTimeRange(LocalDateTime start, LocalDateTime end);
 
     /**
      * Retrieve all the ping logs filtered by IP
      * @param ipAddress IP address use to filter the results
-     * @return List of ping results
+     * @return List of ping results and metadata {@link PingSessionExtract}
      */
-    List<PingSessionResponseEntity> getPingsByIp(String ipAddress);
+    PingSessionExtract getPingsByIp(String ipAddress);
 
     /**
      * Retrieve all the ping logs within a datetime range filtered by IP
      * @param start start date and time of the range
      * @param end end date in the range
      * @param ipAddress IP address use to filter the results
-     * @return List of ping results
+     * @return List of ping results and metadata {@link PingSessionExtract}
      */
-    List<PingSessionResponseEntity> getPingsByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress);
+    PingSessionExtract getPingsByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress);
 
     /**
      * Get the average of lost pings within a list of pings filtered by IP

--- a/src/main/java/com/adieser/conntest/service/ConnTestServiceImpl.java
+++ b/src/main/java/com/adieser/conntest/service/ConnTestServiceImpl.java
@@ -1,6 +1,6 @@
 package com.adieser.conntest.service;
 
-import com.adieser.conntest.controllers.responses.PingSessionResponseEntity;
+import com.adieser.conntest.controllers.responses.PingSessionExtract;
 import com.adieser.conntest.models.ConnTest;
 import com.adieser.conntest.models.PingLog;
 import com.adieser.conntest.models.PingLogRepository;
@@ -73,47 +73,43 @@ public class ConnTestServiceImpl implements ConnTestService {
     }
 
     @Override
-    public List<PingSessionResponseEntity> getPings() {
-        List<PingSessionResponseEntity> pingResponses = new ArrayList<>();
-
+    public PingSessionExtract getPings() {
         List<PingLog> pingLogs = pingLogRepository.findAllPingLogs();
 
-        createResponse(pingResponses, pingLogs);
-
-        return pingResponses;
+        return createBasicResponse(pingLogs);
     }
 
     @Override
-    public List<PingSessionResponseEntity> getPingsByDateTimeRange(LocalDateTime start, LocalDateTime end) {
-        List<PingSessionResponseEntity> pingResponses = new ArrayList<>();
-
+    public PingSessionExtract getPingsByDateTimeRange(LocalDateTime start, LocalDateTime end) {
         List<PingLog> pingLogs = pingLogRepository.findPingLogsByDateTimeRange(start, end);
 
-        createResponse(pingResponses, pingLogs);
+        PingSessionExtract response = createBasicResponse(pingLogs);
+        response.setStartDate(start);
+        response.setEndDate(end);
 
-        return pingResponses;
+        return response;
     }
 
     @Override
-    public List<PingSessionResponseEntity> getPingsByIp(String ipAddress) {
-        List<PingSessionResponseEntity> pingResponses = new ArrayList<>();
-
+    public PingSessionExtract getPingsByIp(String ipAddress) {
         List<PingLog> pingLogs = pingLogRepository.findPingLogByIp(ipAddress);
 
-        createResponse(pingResponses, pingLogs);
+        PingSessionExtract response = createBasicResponse(pingLogs);
+        response.setIpAddress(ipAddress);
 
-        return pingResponses;
+        return response;
     }
 
     @Override
-    public List<PingSessionResponseEntity> getPingsByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) {
-        List<PingSessionResponseEntity> pingResponses = new ArrayList<>();
-
+    public PingSessionExtract getPingsByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) {
         List<PingLog> pingLogs = pingLogRepository.findPingLogsByDateTimeRangeByIp(start, end, ipAddress);
 
-        createResponse(pingResponses, pingLogs);
+        PingSessionExtract response = createBasicResponse(pingLogs);
+        response.setStartDate(start);
+        response.setEndDate(end);
+        response.setIpAddress(ipAddress);
 
-        return pingResponses;
+        return response;
     }
 
     @Override
@@ -127,17 +123,14 @@ public class ConnTestServiceImpl implements ConnTestService {
     }
 
     /**
-     * Create the ping session results formatted as {@link PingSessionResponseEntity}
-     * @param pingResponses List carrying the {@link PingSessionResponseEntity}
+     * Create the ping session results formatted as {@link PingSessionExtract}
      * @param pingLogs List of ping sessions results
      */
-    void createResponse(List<PingSessionResponseEntity> pingResponses, List<PingLog> pingLogs) {
-        pingResponses.add(
-                PingSessionResponseEntity.builder()
-                        .pingLogs(pingLogs)
-                        .amountOfPings(pingLogs.size())
-                        .build()
-        );
+    PingSessionExtract createBasicResponse(List<PingLog> pingLogs) {
+        return PingSessionExtract.builder()
+                .pingLogs(pingLogs)
+                .amountOfPings(pingLogs.size())
+                .build();
     }
 
     /**

--- a/src/main/java/com/adieser/conntest/utils/HATEOASLinkRelValueTemplates.java
+++ b/src/main/java/com/adieser/conntest/utils/HATEOASLinkRelValueTemplates.java
@@ -1,0 +1,14 @@
+package com.adieser.conntest.utils;
+
+public class HATEOASLinkRelValueTemplates {
+
+    private HATEOASLinkRelValueTemplates(){}
+
+    public static final String START_TEST_SESSION = "startTestSession";
+    public static final String STOP_TEST_SESSION = "stopTestSession";
+    public static final String GET_BY_IP = "getByIP-%s";
+    public static final String GET_30_MINS_NEIGHBORHOOD = "get30MinsNeighborhood";
+    public static final String GET_30_MINS_NEIGHBORHOOD_BY_IP = "get30MinsNeighborhoodByIP-%s";
+    public static final String GET_LOST_AVG_BY_IP = "getLostAvgByIP-%s";
+    public static final String GET_30_MINS_NEIGHBORHOOD_LOST_AVG_BY_IP = "get30MinsNeighborhoodLostAvgByIP-%s";
+}

--- a/src/main/java/com/adieser/conntest/utils/NotIncludeInCodeCoverageGenerated.java
+++ b/src/main/java/com/adieser/conntest/utils/NotIncludeInCodeCoverageGenerated.java
@@ -1,0 +1,19 @@
+package com.adieser.conntest.utils;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * This annotation is used to exclude classes or methods from coverage report
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, CONSTRUCTOR})
+public @interface NotIncludeInCodeCoverageGenerated {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,3 @@
 logging.file.name=logs/appLog.log
 
-spring.datasource.url=jdbc:h2:file:./db
-spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=password
-spring.h2.console.enabled=true
-
 conntest.pinglogs.path = src/main/resources/pingLogs

--- a/src/test/java/com/adieser/conntest/controllers/responses/AverageResponseTest.java
+++ b/src/test/java/com/adieser/conntest/controllers/responses/AverageResponseTest.java
@@ -1,0 +1,49 @@
+package com.adieser.conntest.controllers.responses;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
+import static com.adieser.utils.PingLogUtils.LOCAL_IP_ADDRESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class AverageResponseTest {
+
+    private static final BigDecimal DEFAULT_AVERAGE = new BigDecimal(1);
+
+    @ParameterizedTest
+    @MethodSource("averageProvider")
+    void testEquals(BigDecimal avg) {
+        AverageResponse avgResponse1 = buildAvgResponse(DEFAULT_AVERAGE);
+        AverageResponse avgResponse2 = buildAvgResponse(avg);
+
+        if(avg.compareTo(DEFAULT_AVERAGE) == 0) {
+            assertEquals(avgResponse1, avgResponse2);
+            assertEquals(avgResponse1.hashCode(), avgResponse2.hashCode());
+        }
+        else {
+            assertNotEquals(avgResponse1, avgResponse2);
+            assertNotEquals(avgResponse1.hashCode(), avgResponse2.hashCode());
+        }
+    }
+
+    private static AverageResponse buildAvgResponse(BigDecimal avg) {
+        return AverageResponse.builder()
+                .startDate(LocalDateTime.of(2023, 11, 10, 0, 0, 0))
+                .endDate(LocalDateTime.of(2023, 11, 11, 0, 0, 0))
+                .ipAddress(LOCAL_IP_ADDRESS)
+                .average(avg)
+                .build();
+    }
+
+    static Stream<BigDecimal> averageProvider() {
+        return Stream.of(
+                new BigDecimal(1),
+                new BigDecimal("0.5")
+        );
+    }
+}

--- a/src/test/java/com/adieser/conntest/service/ConnTestServiceImplTest.java
+++ b/src/test/java/com/adieser/conntest/service/ConnTestServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.adieser.conntest.service;
 
-import com.adieser.conntest.controllers.responses.PingSessionResponseEntity;
+import com.adieser.conntest.controllers.responses.PingSessionExtract;
 import com.adieser.conntest.models.ConnTest;
 import com.adieser.conntest.models.PingLog;
 import com.adieser.conntest.models.PingLogRepository;
@@ -113,7 +113,7 @@ class ConnTestServiceImplTest {
         doReturn(pingLogs).when(pingLogRepository).findAllPingLogs();
 
         // then
-        List<PingSessionResponseEntity> pings = underTest.getPings();
+        PingSessionExtract pings = underTest.getPings();
 
         // assert
         assertPingSessionResponseEntities(pingLogs, pings);
@@ -127,7 +127,7 @@ class ConnTestServiceImplTest {
         doReturn(pingLogs).when(pingLogRepository).findPingLogsByDateTimeRange(START, END);
 
         // then
-        List<PingSessionResponseEntity> pings = underTest.getPingsByDateTimeRange(
+        PingSessionExtract pings = underTest.getPingsByDateTimeRange(
                 START,
                 END
         );
@@ -144,7 +144,7 @@ class ConnTestServiceImplTest {
         doReturn(pingLogs).when(pingLogRepository).findPingLogByIp(LOCAL_IP_ADDRESS);
 
         // then
-        List<PingSessionResponseEntity> pings = underTest.getPingsByIp(LOCAL_IP_ADDRESS);
+        PingSessionExtract pings = underTest.getPingsByIp(LOCAL_IP_ADDRESS);
 
         // assert
         assertPingSessionResponseEntities(pingLogs, pings);
@@ -162,7 +162,7 @@ class ConnTestServiceImplTest {
         );
 
         // then
-        List<PingSessionResponseEntity> pings = underTest.getPingsByDateTimeRangeByIp(
+        PingSessionExtract pings = underTest.getPingsByDateTimeRangeByIp(
                 START,
                 END,
                 LOCAL_IP_ADDRESS
@@ -215,17 +215,16 @@ class ConnTestServiceImplTest {
         List<PingLog> pingLogs = List.of(getDefaultPingLog());
 
         // then
-        List<PingSessionResponseEntity> responses = new ArrayList<>();
-        underTest.createResponse(responses, pingLogs);
+        PingSessionExtract response = underTest.createBasicResponse(pingLogs);
 
         // assert
-        PingSessionResponseEntity expectedResponse = PingSessionResponseEntity.builder()
+        PingSessionExtract expectedResponse = PingSessionExtract.builder()
                 .pingLogs(pingLogs)
                 .amountOfPings(pingLogs.size())
                 .build();
 
-        assertEquals(1, responses.size());
-        assertEquals(expectedResponse, responses.get(0));
+        assertEquals(1, response.getPingLogs().size());
+        assertEquals(expectedResponse, response);
     }
 
     @Test
@@ -315,13 +314,13 @@ class ConnTestServiceImplTest {
         );
     }
 
-    private static void assertPingSessionResponseEntities(List<PingLog> pingLogs, List<PingSessionResponseEntity> pings) {
+    private static void assertPingSessionResponseEntities(List<PingLog> pingLogs, PingSessionExtract pings) {
         if(pingLogs.isEmpty()) {
-            assertEquals(0, pings.get(0).getAmountOfPings());
-            assertTrue(pings.get(0).getPingLogs().isEmpty());
+            assertEquals(0, pings.getAmountOfPings());
+            assertTrue(pings.getPingLogs().isEmpty());
         }else{
-            assertEquals(1, pings.get(0).getAmountOfPings());
-            PingLog pingLog = pings.get(0).getPingLogs().get(0);
+            assertEquals(1, pings.getAmountOfPings());
+            PingLog pingLog = pings.getPingLogs().get(0);
             assertEquals(DEFAULT_PING_TIME, pingLog.getPingTime());
             assertEquals(DEFAULT_LOG_DATE_TIME, pingLog.getDateTime());
             assertEquals(LOCAL_IP_ADDRESS, pingLog.getIpAddress());


### PR DESCRIPTION
## Overview
There are 3 kind of HATEOAS links in this PR. For start and stop tests, for all the methods that return PingLogs and another kind for the methods that return average numbers. Some responses classes had to be refactored in order to implement HATEOAS

## Changes
- remove deprecated database properties
- refactor AverageResponse, add metadata
- add HATEOAS links
- add tests for HATEOAS links
- refactor PingLog responses in ContTestController.
- add the capability of excluding classes and methods from coverage report