### PR TITLE
CON-25 start ping tests and stop tests is not working properly

### DIFF
--- a/src/main/java/com/adieser/conntest/service/ConnTestServiceImpl.java
+++ b/src/main/java/com/adieser/conntest/service/ConnTestServiceImpl.java
@@ -37,7 +37,7 @@ public class ConnTestServiceImpl implements ConnTestService {
     /**
      * Tracert IP regex (Windows) for extracting the IP addresses from tracert output
      */
-    private static final String REGEX_PATTERN_TRACERT_WINDOWS = "(?<!\\[)(\\b(?:\\d{1,3}\\.){3}\\d{1,3}\\b)(?!])";
+    private static final String REGEX_PATTERN_TRACERT_WINDOWS = "(?<!\\[)(\\b(?:\\d{1,3}\\.){3}\\d{1,3}\\b)(?!])\\b(?<!8\\.8\\.8\\.8)";
 
     private final PingLogRepository pingLogRepository;
 
@@ -59,7 +59,7 @@ public class ConnTestServiceImpl implements ConnTestService {
 
             tests.forEach(Pingable::startPingSession);
         }else
-            logger.warn("Tests are already running");
+            tests.forEach(test -> logger.warn("Tests are already running (IP {})", test.getIpAddress()));
     }
 
     @Override
@@ -68,7 +68,7 @@ public class ConnTestServiceImpl implements ConnTestService {
             logger.warn("No tests to stop");
         else {
             tests.forEach(Pingable::stopPingSession);
-            threadPoolExecutor.shutdown();
+            tests = new ArrayList<>();
         }
     }
 
@@ -176,5 +176,15 @@ public class ConnTestServiceImpl implements ConnTestService {
      */
     Optional<BufferedReader> executeTracert() throws IOException {
         return tracertProvider.executeTracert();
+    }
+
+    /**
+     * Get the IP addresses from the active tests
+     * @return list of IP addresses
+     */
+    public List<String> getIpAddressesFromActiveTests(){
+        return tests.stream()
+                .map(ConnTest::getIpAddress)
+                .toList();
     }
 }

--- a/src/test/java/com/adieser/conntest/service/ConnTestServiceImplTest.java
+++ b/src/test/java/com/adieser/conntest/service/ConnTestServiceImplTest.java
@@ -18,8 +18,10 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Stream;
 
@@ -298,6 +300,26 @@ class ConnTestServiceImplTest {
         // assert
         verify(tracertProvider, times(1)).executeTracert();
         assertEquals(mockReader, reader);
+    }
+
+    @Test
+    void testGetIpAddressesFromActiveTests(){
+        // when
+        ConnTestServiceImpl underTest = spy(new ConnTestServiceImpl(executorService, logger, tracertProvider, pingLogRepository));
+        List<String> ipAddresses = List.of("IP_1", "IP_2", "IP_3");
+        underTest.tests = ipAddresses.stream()
+                .map(ip -> new ConnTest(executorService, ip, logger, pingLogRepository))
+                .toList();
+
+        // then
+        List<String> result = underTest.getIpAddressesFromActiveTests();
+
+        // assert
+        // convert the lists to set to compare ignoring the ordering
+        Set<String> expected = new HashSet<>(ipAddresses);
+        Set<String> testResult = new HashSet<>(result);
+
+        assertEquals(expected, testResult);
     }
 
     static Stream<Boolean> areTestsRunningProvider() {


### PR DESCRIPTION
- fix regex that was retrieving 8.8.8.8 from tracert output twice
- add ip to the warning when tests are already running
- fix stopTest method
- add new method to retrieve IP addresses that are being tested