### PR TITLE
CON-26 Create a new endpoint to ping custom IPs

### DIFF
--- a/src/main/java/com/adieser/conntest/controllers/ConnTestController.java
+++ b/src/main/java/com/adieser/conntest/controllers/ConnTestController.java
@@ -11,10 +11,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
+import static com.adieser.conntest.controllers.responses.ErrorResponse.MAX_IP_ADDRESSES_EXCEEDED;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
@@ -47,6 +50,24 @@ public class ConnTestController {
                 .withRel(HATEOASLinkRelValueTemplates.STOP_TEST_SESSION));
 
         return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    /**
+     * Trigger up to 3 custom ip addresses ping sessions to test connection
+     */
+    @PostMapping(value = "/test-custom-ips", produces = {"application/json"})
+    public ResponseEntity<Object> testCustomIps(@RequestBody List<String> ipAddresses) {
+        HttpStatus httpStatus = HttpStatus.OK;
+
+        if(ipAddresses.size() > 3)
+            return ResponseEntity.badRequest().body(MAX_IP_ADDRESSES_EXCEEDED);
+
+        connTestService.testCustomIps(ipAddresses);
+        PingTestResponse pingResponse = new PingTestResponse();
+        pingResponse.add(linkTo(methodOn(ConnTestController.class).stopTests())
+                .withRel(HATEOASLinkRelValueTemplates.STOP_TEST_SESSION));
+
+        return new ResponseEntity<>(pingResponse, httpStatus);
     }
 
     /**

--- a/src/main/java/com/adieser/conntest/controllers/responses/ErrorResponse.java
+++ b/src/main/java/com/adieser/conntest/controllers/responses/ErrorResponse.java
@@ -1,0 +1,17 @@
+package com.adieser.conntest.controllers.responses;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ErrorResponse {
+
+    public static final ErrorResponse MAX_IP_ADDRESSES_EXCEEDED = ErrorResponse.builder()
+            .errorCode(1L)
+            .errorMessage("Max IP Addresses exceeded (3)")
+            .build();
+
+    private Long errorCode;
+    private String errorMessage;
+}

--- a/src/main/java/com/adieser/conntest/service/ConnTestService.java
+++ b/src/main/java/com/adieser/conntest/service/ConnTestService.java
@@ -16,6 +16,12 @@ public interface ConnTestService {
     void testLocalISPInternet();
 
     /**
+     * Trigger a 3 custom Ip addresses in parallel
+     * @param ipAddresses ip addresses to test connection to
+     */
+    void testCustomIps(List<String> ipAddresses);
+
+    /**
      * Stop all the threads running ping sessions
      */
     void stopTests();
@@ -71,5 +77,4 @@ public interface ConnTestService {
      * @return list of IP addresses
      */
     List<String> getIpAddressesFromActiveTests();
-
 }

--- a/src/main/java/com/adieser/conntest/service/ConnTestServiceImpl.java
+++ b/src/main/java/com/adieser/conntest/service/ConnTestServiceImpl.java
@@ -51,12 +51,15 @@ public class ConnTestServiceImpl implements ConnTestService {
 
     @Override
     public void testLocalISPInternet(){
-        if(tests.isEmpty()){
             List<String> ipAddresses = getLocalAndISPIpAddresses();
             ipAddresses.add(CLOUD_IP);
+            testCustomIps(ipAddresses);
+    }
 
+    @Override
+    public void testCustomIps(List<String> ipAddresses) {
+        if(tests.isEmpty()){
             tests = getConnTestsFromIpAddresses(ipAddresses);
-
             tests.forEach(Pingable::startPingSession);
         }else
             tests.forEach(test -> logger.warn("Tests are already running (IP {})", test.getIpAddress()));


### PR DESCRIPTION
## Overview
This change adds a new endpoint for testing up to 3 custom ip addresses. It also adds a new class to handle the controller error responses. For now, there's only one error being handled this way

## Changes
- add new controller endpoint
- add unit tests
- add integration test
- add ErrorResponse for controller error response