### PR TITLE
CON-43 WindowsTracertProviderImplTest fails in Jenkins

### DIFF
--- a/src/test/java/com/adieser/conntest/service/WindowsTracertProviderImplTest.java
+++ b/src/test/java/com/adieser/conntest/service/WindowsTracertProviderImplTest.java
@@ -50,8 +50,8 @@ class WindowsTracertProviderImplTest {
             Runtime mockRuntime = mock(Runtime.class);
             Process mockProcess = mock(Process.class);
             when(mockProcess.getInputStream()) .thenReturn(mock(InputStream.class));
+            doReturn(mockProcess).when(mockRuntime).exec(anyString());
 
-            when(mockRuntime.exec(anyString())).thenReturn(mockProcess);
             runtime.when(Runtime::getRuntime).thenReturn(mockRuntime);
         }
 


### PR DESCRIPTION
## Overview
Currently Jenkns is running on a Docker Ubuntu container. When the `mvn install` command runs in the build it fails due to **WindowsTracertProviderImplTest.testExecuteTracertUsingRuntime()** test tries to execute tracert command. The fix is to prevent this command from running, it must be mocked.

## Changes
- fix WindowsTracertProviderImplTest to avoid executing tracert command in the OS