### PR TITLE
CON-43 WindowsTracertProviderImplTest fails in Jenkins

### DIFF
--- a/src/test/java/com/adieser/conntest/service/WindowsTracertProviderImplTest.java
+++ b/src/test/java/com/adieser/conntest/service/WindowsTracertProviderImplTest.java
@@ -49,15 +49,15 @@ class WindowsTracertProviderImplTest {
         try (MockedStatic<Runtime> runtime = Mockito.mockStatic(Runtime.class)) {
             Runtime mockRuntime = mock(Runtime.class);
             Process mockProcess = mock(Process.class);
+            runtime.when(Runtime::getRuntime).thenReturn(mockRuntime);
+
             when(mockProcess.getInputStream()) .thenReturn(mock(InputStream.class));
             doReturn(mockProcess).when(mockRuntime).exec(anyString());
 
-            runtime.when(Runtime::getRuntime).thenReturn(mockRuntime);
+            WindowsTracertProviderImpl underTest = spy(new WindowsTracertProviderImpl());
+            Optional<BufferedReader> bufferedReader = underTest.executeTracert();
+
+            assertTrue(bufferedReader.isPresent());
         }
-
-        WindowsTracertProviderImpl underTest = spy(new WindowsTracertProviderImpl());
-        Optional<BufferedReader> bufferedReader = underTest.executeTracert();
-
-        assertTrue(bufferedReader.isPresent());
     }
 }


### PR DESCRIPTION
## Overview
Currently Jenkns is running on a Docker Ubuntu container. When the `mvn install` command runs in the build it fails due to **WindowsTracertProviderImplTest.testExecuteTracertUsingRuntime()** test tries to execute tracert command. The fix is to prevent this command from running, it must be mocked.

## Changes
- fix WindowsTracertProviderImplTest to avoid executing tracert command in the OS