### PR TITLE
CON-27 - Handle exceptions properly

### DIFF
--- a/src/main/java/com/adieser/conntest/exceptions/handlers/GlobalExceptionHandler.java
+++ b/src/main/java/com/adieser/conntest/exceptions/handlers/GlobalExceptionHandler.java
@@ -1,0 +1,32 @@
+package com.adieser.conntest.exceptions.handlers;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * All the exceptions, checked and unchecked, are handled by this handler
+     * @param ex exception to be handled
+     * @return generic error response
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleException(Exception ex) {
+        return new ResponseEntity<>("Internal Server Error", HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Handles HttpClientErrorException.BadRequest
+     * @param ex exception to be handled
+     * @return generic error response
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<String> handleBadRequestException(MethodArgumentTypeMismatchException ex) {
+        return new ResponseEntity<>("Bad Request", HttpStatus.BAD_REQUEST);
+    }
+}
+


### PR DESCRIPTION
## Overview
All the errors and exceptions happening during the execution were handled by default. To avoid the risk of showing the stacktrace in the REST response, we handle every exception explicitly

## Changes
- add a bad request handler
- add a global exception handler