### PR TITLE
CON-50 Send the IOException upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ build/
 /logs/
 /src/main/resources/pingLogs/
 /db.mv.db
+/ngrok-v3-stable-windows-amd64/README.txt
+/ngrok-v3-stable-windows-amd64/ngrok.exe

--- a/src/main/java/com/adieser/conntest/controllers/ConnTestController.java
+++ b/src/main/java/com/adieser/conntest/controllers/ConnTestController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -103,7 +104,7 @@ public class ConnTestController {
     @ApiResponse(responseCode = "200", description = "a list of pings along with the total count.")
     @GetMapping("/pings")
     @Operation(summary = "Get all pings")
-    public ResponseEntity<PingSessionExtract> getPings() {
+    public ResponseEntity<PingSessionExtract> getPings() throws IOException {
         HttpStatus httpStatus = HttpStatus.OK;
         PingSessionExtract pings = connTestService.getPings();
 
@@ -132,7 +133,7 @@ public class ConnTestController {
             @Parameter(
                     description = "End date in the range",
                     required = true)
-            @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime end) {
+            @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime end) throws IOException {
         HttpStatus httpStatus = HttpStatus.OK;
         PingSessionExtract pings = connTestService.getPingsByDateTimeRange(start, end);
 
@@ -156,7 +157,7 @@ public class ConnTestController {
             @Parameter(
                     description = "IP address used to filter the results",
                     required = true)
-            @PathVariable String ipAddress) {
+            @PathVariable String ipAddress) throws IOException {
         HttpStatus httpStatus = HttpStatus.OK;
         PingSessionExtract pings = connTestService.getPingsByIp(ipAddress);
 
@@ -190,7 +191,7 @@ public class ConnTestController {
             @Parameter(
                     description = "End date in the range",
                     required = true)
-            @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime end) {
+            @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime end) throws IOException {
         HttpStatus httpStatus = HttpStatus.OK;
         PingSessionExtract pings = connTestService.getPingsByDateTimeRangeByIp(start, end, ipAddress);
 
@@ -214,7 +215,7 @@ public class ConnTestController {
             @Parameter(
                     description = "IP address used to filter the results",
                     required = true)
-            @PathVariable String ipAddress) {
+            @PathVariable String ipAddress) throws IOException {
 
         AverageResponse averageResult = AverageResponse.builder()
                 .ipAddress(ipAddress)
@@ -254,7 +255,7 @@ public class ConnTestController {
             @Parameter(
                     description = "End date in the range",
                     required = true)
-            @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime end) {
+            @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime end) throws IOException {
 
         AverageResponse averageResult = AverageResponse.builder()
                 .ipAddress(ipAddress)
@@ -278,18 +279,26 @@ public class ConnTestController {
             LocalDateTime roof = ping.getDateTime().plusMinutes(30);
             String ipAddress = ping.getIpAddress();
 
-            ping.add(
-                    linkTo(methodOn(ConnTestController.class).getPingsByIp(ipAddress))
-                            .withRel(HATEOASLinkRelValueTemplates.GET_BY_IP.formatted(ipAddress)),
-                    linkTo(methodOn(ConnTestController.class).getPingsByDateTimeRange(floor, roof))
-                            .withRel(HATEOASLinkRelValueTemplates.GET_30_MINS_NEIGHBORHOOD),
-                    linkTo(methodOn(ConnTestController.class).getPingsByDateTimeRangeByIp(ipAddress, floor, roof))
-                            .withRel(HATEOASLinkRelValueTemplates.GET_30_MINS_NEIGHBORHOOD_BY_IP.formatted(ipAddress)),
-                    linkTo(methodOn(ConnTestController.class).getPingsLostAvgByIp(ping.getIpAddress()))
-                            .withRel(HATEOASLinkRelValueTemplates.GET_LOST_AVG_BY_IP.formatted(ipAddress)),
-                    linkTo(methodOn(ConnTestController.class).getPingsLostAvgByDateTimeRangeByIp(ipAddress, floor, roof))
-                            .withRel(HATEOASLinkRelValueTemplates.GET_30_MINS_NEIGHBORHOOD_LOST_AVG_BY_IP.formatted(ipAddress))
-            );
+            try {
+                ping.add(
+                        linkTo(methodOn(ConnTestController.class).getPingsByIp(ipAddress))
+                                .withRel(HATEOASLinkRelValueTemplates.GET_BY_IP.formatted(ipAddress)),
+                        linkTo(methodOn(ConnTestController.class).getPingsByDateTimeRange(floor, roof))
+                                .withRel(HATEOASLinkRelValueTemplates.GET_30_MINS_NEIGHBORHOOD),
+                        linkTo(methodOn(ConnTestController.class).getPingsByDateTimeRangeByIp(ipAddress, floor, roof))
+                                .withRel(HATEOASLinkRelValueTemplates.GET_30_MINS_NEIGHBORHOOD_BY_IP.formatted(ipAddress)),
+                        linkTo(methodOn(ConnTestController.class).getPingsLostAvgByIp(ping.getIpAddress()))
+                                .withRel(HATEOASLinkRelValueTemplates.GET_LOST_AVG_BY_IP.formatted(ipAddress)),
+                        linkTo(methodOn(ConnTestController.class).getPingsLostAvgByDateTimeRangeByIp(ipAddress, floor, roof))
+                                .withRel(HATEOASLinkRelValueTemplates.GET_30_MINS_NEIGHBORHOOD_LOST_AVG_BY_IP.formatted(ipAddress))
+                );
+            } catch (IOException ignored){
+                /*
+                    dummy exception thrown by the methods in the HATEOAS links, methods that are never executed
+                    in that code block, they serve only as reference to the links
+                */
+            }
+
         });
     }
 }

--- a/src/main/java/com/adieser/conntest/models/CsvPingLogRepository.java
+++ b/src/main/java/com/adieser/conntest/models/CsvPingLogRepository.java
@@ -36,7 +36,6 @@ import java.util.stream.Stream;
 public class CsvPingLogRepository implements PingLogRepository {
     public static final String SAVE_PING_ERROR_MSG = "Save Ping error";
     public static final String PING_LOG_NAME = "ping.log";
-    public static final String PARSE_ERROR = "Parse error";
     private final String path;
 
     private final Logger logger;
@@ -78,30 +77,30 @@ public class CsvPingLogRepository implements PingLogRepository {
     }
 
     @Override
-    public List<PingLog> findAllPingLogs() {
+    public List<PingLog> findAllPingLogs() throws IOException {
        return readAll();
     }
 
     @Override
-    public List<PingLog> findPingLogByIp(String ipAddress) {
+    public List<PingLog> findPingLogByIp(String ipAddress) throws IOException {
         return getPingLogsByIpStream(readAll().stream(), ipAddress)
                 .toList();
     }
 
     @Override
-    public List<PingLog> findPingLogsByDateTimeRange(LocalDateTime start, LocalDateTime end) {
+    public List<PingLog> findPingLogsByDateTimeRange(LocalDateTime start, LocalDateTime end) throws IOException {
         return getPingLogsByDateTimeRangeStream(readAll().stream(), start, end)
                 .toList();
     }
 
     @Override
-    public List<PingLog> findPingLogsByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) {
+    public List<PingLog> findPingLogsByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException {
         return getPingLogsByDateTimeRangeByIpStream(readAll().stream(), start, end, ipAddress)
                 .toList();
     }
 
     @Override
-    public BigDecimal findLostPingLogsAvgByIP(String ipAddress) {
+    public BigDecimal findLostPingLogsAvgByIP(String ipAddress) throws IOException {
 
         List<PingLog> pingLogsByIp = getPingLogsByIpStream(readAll().stream(), ipAddress).toList();
 
@@ -118,7 +117,7 @@ public class CsvPingLogRepository implements PingLogRepository {
     }
 
     @Override
-    public BigDecimal findLostPingLogsAvgByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) {
+    public BigDecimal findLostPingLogsAvgByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException {
         List<PingLog> pingLogsInDateTimeRange = getPingLogsByDateTimeRangeByIpStream(readAll().stream(), start, end, ipAddress)
                 .toList();
 
@@ -138,16 +137,11 @@ public class CsvPingLogRepository implements PingLogRepository {
      * Retrieve all the pings from the CSV file
      * @return List of pings
      */
-    protected List<PingLog> readAll(){
-        try (Reader reader = getReader()) {
-            CsvToBean<PingLog> cb = getCsvToBean(reader);
+    protected List<PingLog> readAll() throws IOException {
+        Reader reader = getReader();
+        CsvToBean<PingLog> cb = getCsvToBean(reader);
 
-            return cb.parse();
-        } catch (IOException e) {
-            logger.error(PARSE_ERROR, e);
-        }
-
-        return List.of();
+        return cb.parse();
     }
 
     BufferedReader getReader() throws IOException {

--- a/src/main/java/com/adieser/conntest/models/PingLogRepository.java
+++ b/src/main/java/com/adieser/conntest/models/PingLogRepository.java
@@ -2,6 +2,7 @@ package com.adieser.conntest.models;
 
 import org.springframework.stereotype.Repository;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -23,13 +24,13 @@ public interface PingLogRepository {
      * @param ipAddress IP address to filter the pings
      * @return List of pings
      */
-    List<PingLog> findPingLogByIp(String ipAddress);
+    List<PingLog> findPingLogByIp(String ipAddress) throws IOException;
 
     /**
      * Retrieve all pings in the database
      * @return List of pings
      */
-    List<PingLog> findAllPingLogs();
+    List<PingLog> findAllPingLogs() throws IOException;
 
     /**
      * Retrieve all pings within a datetime range
@@ -37,7 +38,7 @@ public interface PingLogRepository {
      * @param end end date in the range
      * @return List of pings
      */
-    List<PingLog> findPingLogsByDateTimeRange(LocalDateTime start, LocalDateTime end);
+    List<PingLog> findPingLogsByDateTimeRange(LocalDateTime start, LocalDateTime end) throws IOException;
 
     /**
      * Retrieve all pings within a datetime range filtered by IP address
@@ -46,14 +47,14 @@ public interface PingLogRepository {
      * @param ipAddress IP address to filter the pings
      * @return List of pings
      */
-    List<PingLog> findPingLogsByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress);
+    List<PingLog> findPingLogsByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException;
 
     /**
      * Calculate and retrieve the average of lost pings within a list of pings filtered by IP address
      * @param ipAddress IP address use to filter the results
      * @return average of lost pings
      */
-    BigDecimal findLostPingLogsAvgByIP(String ipAddress);
+    BigDecimal findLostPingLogsAvgByIP(String ipAddress) throws IOException;
 
     /** Calculate and retrieve the average of lost pings within a list of pings within a datetime range filtered
      * by IP address
@@ -62,6 +63,6 @@ public interface PingLogRepository {
      * @param ipAddress IP address use to filter the results
      * @return average of lost pings
      */
-    BigDecimal findLostPingLogsAvgByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress);
+    BigDecimal findLostPingLogsAvgByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException;
 
 }

--- a/src/main/java/com/adieser/conntest/service/ConnTestService.java
+++ b/src/main/java/com/adieser/conntest/service/ConnTestService.java
@@ -2,6 +2,7 @@ package com.adieser.conntest.service;
 
 import com.adieser.conntest.controllers.responses.PingSessionExtract;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -30,7 +31,7 @@ public interface ConnTestService {
      * Retrieve all the ping logs
      * @return List of ping results and metadata {@link PingSessionExtract}
      */
-    PingSessionExtract getPings();
+    PingSessionExtract getPings() throws IOException;
 
     /**
      * Retrieve all the ping logs within a datetime range
@@ -38,14 +39,14 @@ public interface ConnTestService {
      * @param end end date in the range
      * @return List of ping results and metadata {@link PingSessionExtract}
      */
-    PingSessionExtract getPingsByDateTimeRange(LocalDateTime start, LocalDateTime end);
+    PingSessionExtract getPingsByDateTimeRange(LocalDateTime start, LocalDateTime end) throws IOException;
 
     /**
      * Retrieve all the ping logs filtered by IP
      * @param ipAddress IP address use to filter the results
      * @return List of ping results and metadata {@link PingSessionExtract}
      */
-    PingSessionExtract getPingsByIp(String ipAddress);
+    PingSessionExtract getPingsByIp(String ipAddress) throws IOException;
 
     /**
      * Retrieve all the ping logs within a datetime range filtered by IP
@@ -54,14 +55,14 @@ public interface ConnTestService {
      * @param ipAddress IP address use to filter the results
      * @return List of ping results and metadata {@link PingSessionExtract}
      */
-    PingSessionExtract getPingsByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress);
+    PingSessionExtract getPingsByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException;
 
     /**
      * Get the average of lost pings within a list of pings filtered by IP
      * @param ipAddress IP address use to filter the results
      * @return average of pings lost
      */
-    BigDecimal getPingsLostAvgByIp(String ipAddress);
+    BigDecimal getPingsLostAvgByIp(String ipAddress) throws IOException;
 
     /**
      * Get the average of lost pings within a list of pings within a datetime range filtered by IP
@@ -70,7 +71,7 @@ public interface ConnTestService {
      * @param ipAddress IP address use to filter the results
      * @return average of pings lost
      */
-    BigDecimal getPingsLostAvgByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress);
+    BigDecimal getPingsLostAvgByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException;
 
     /**
      * Get the IP addresses from the active tests

--- a/src/main/java/com/adieser/conntest/service/ConnTestServiceImpl.java
+++ b/src/main/java/com/adieser/conntest/service/ConnTestServiceImpl.java
@@ -76,14 +76,14 @@ public class ConnTestServiceImpl implements ConnTestService {
     }
 
     @Override
-    public PingSessionExtract getPings() {
+    public PingSessionExtract getPings() throws IOException {
         List<PingLog> pingLogs = pingLogRepository.findAllPingLogs();
 
         return createBasicResponse(pingLogs);
     }
 
     @Override
-    public PingSessionExtract getPingsByDateTimeRange(LocalDateTime start, LocalDateTime end) {
+    public PingSessionExtract getPingsByDateTimeRange(LocalDateTime start, LocalDateTime end) throws IOException {
         List<PingLog> pingLogs = pingLogRepository.findPingLogsByDateTimeRange(start, end);
 
         PingSessionExtract response = createBasicResponse(pingLogs);
@@ -94,7 +94,7 @@ public class ConnTestServiceImpl implements ConnTestService {
     }
 
     @Override
-    public PingSessionExtract getPingsByIp(String ipAddress) {
+    public PingSessionExtract getPingsByIp(String ipAddress) throws IOException {
         List<PingLog> pingLogs = pingLogRepository.findPingLogByIp(ipAddress);
 
         PingSessionExtract response = createBasicResponse(pingLogs);
@@ -104,7 +104,7 @@ public class ConnTestServiceImpl implements ConnTestService {
     }
 
     @Override
-    public PingSessionExtract getPingsByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) {
+    public PingSessionExtract getPingsByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException {
         List<PingLog> pingLogs = pingLogRepository.findPingLogsByDateTimeRangeByIp(start, end, ipAddress);
 
         PingSessionExtract response = createBasicResponse(pingLogs);
@@ -116,12 +116,12 @@ public class ConnTestServiceImpl implements ConnTestService {
     }
 
     @Override
-    public BigDecimal getPingsLostAvgByIp(String ipAddress) {
+    public BigDecimal getPingsLostAvgByIp(String ipAddress) throws IOException {
         return pingLogRepository.findLostPingLogsAvgByIP(ipAddress);
     }
 
     @Override
-    public BigDecimal getPingsLostAvgByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) {
+    public BigDecimal getPingsLostAvgByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException {
         return pingLogRepository.findLostPingLogsAvgByDateTimeRangeByIp(start, end, ipAddress);
     }
 

--- a/src/main/java/com/adieser/conntest/views/UiController.java
+++ b/src/main/java/com/adieser/conntest/views/UiController.java
@@ -136,7 +136,11 @@ public class UiController {
         });
         this.dayFilterBox.setOnAction(actionEvent -> {
             for (int i = 0; i < Math.min(ipAddress.size(), 3); i++) {
-                loadLogs(ipAddress.get(i), tablesList.get(i));
+                try {
+                    loadLogs(ipAddress.get(i), tablesList.get(i));
+                } catch (IOException e) {
+                    logger.error(e.getMessage());
+                }
                 setAverageLost(ipAddress.get(i), labelsList.get(i));
             }
         });
@@ -174,7 +178,11 @@ public class UiController {
     void startExecutorService(Integer timechoice){
         executorService.scheduleAtFixedRate(() -> {
             for (int i = 0; i < Math.min(ipAddress.size(), 3); i++) {
-                loadLogs(ipAddress.get(i), tablesList.get(i));
+                try {
+                    loadLogs(ipAddress.get(i), tablesList.get(i));
+                } catch (IOException e) {
+                    logger.error(e.getMessage());
+                }
                 setAverageLost(ipAddress.get(i), labelsList.get(i));
             }
         }, 0, timechoice, TimeUnit.SECONDS);
@@ -277,7 +285,7 @@ public class UiController {
     /**
      * Loads ping logs for each table view
      */
-    public void loadLogs(String ip, TableView<PingLog> table) {
+    public void loadLogs(String ip, TableView<PingLog> table) throws IOException {
         if (!dayFilterBox.isSelected()) {
             addPingLogsToTableView(connTestService.getPingsByIp(ip),table);
         } else {
@@ -308,12 +316,16 @@ public class UiController {
     public void setAverageLost(String ip, Label label) {
         final String text = "Average lost pings: ";
         Platform.runLater(() -> {
-            if (!dayFilterBox.isSelected()) {
-                label.setText(text + connTestService.getPingsLostAvgByIp(ip) + "%");
-            } else {
-                LocalDateTime currentDayStartTime = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
-                LocalDateTime currentDayEndTime = LocalDateTime.now().withHour(23).withMinute(59).withSecond(59).withNano(999999999);
-                label.setText(text + connTestService.getPingsLostAvgByDateTimeRangeByIp(currentDayStartTime, currentDayEndTime, ip) + "%");
+            try {
+                if (!dayFilterBox.isSelected()) {
+                    label.setText(text + connTestService.getPingsLostAvgByIp(ip) + "%");
+                } else {
+                    LocalDateTime currentDayStartTime = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
+                    LocalDateTime currentDayEndTime = LocalDateTime.now().withHour(23).withMinute(59).withSecond(59).withNano(999999999);
+                    label.setText(text + connTestService.getPingsLostAvgByDateTimeRangeByIp(currentDayStartTime, currentDayEndTime, ip) + "%");
+                }
+            } catch (IOException e) {
+                logger.error(e.getMessage());
             }
         });
     }

--- a/src/test/java/com/adieser/conntest/exceptions/handlers/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/adieser/conntest/exceptions/handlers/GlobalExceptionHandlerTest.java
@@ -1,0 +1,38 @@
+package com.adieser.conntest.exceptions.handlers;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+class GlobalExceptionHandlerTest {
+
+    @Test
+    void testHandleIOException() {
+        // when
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+        // then
+        ResponseEntity<String> response = handler.handleException(mock(Exception.class));
+
+        // assert
+        assertEquals("Internal Server Error", response.getBody());
+        assertEquals(500, response.getStatusCode().value());
+    }
+
+
+    @Test
+    void testHandleMethodArgumentTypeMismatchExceptionException() {
+        // when
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+        // then
+        ResponseEntity<String> response = handler.handleBadRequestException(mock(MethodArgumentTypeMismatchException.class));
+
+        // assert
+        assertEquals("Bad Request", response.getBody());
+        assertEquals(400, response.getStatusCode().value());
+    }
+}

--- a/src/test/java/com/adieser/conntest/models/CsvPingLogRepositoryTest.java
+++ b/src/test/java/com/adieser/conntest/models/CsvPingLogRepositoryTest.java
@@ -26,6 +26,7 @@ import static com.adieser.utils.PingLogUtils.CLOUD_IP_ADDRESS;
 import static com.adieser.utils.PingLogUtils.LOCAL_IP_ADDRESS;
 import static com.adieser.utils.PingLogUtils.getDefaultPingLog;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -80,15 +81,13 @@ class CsvPingLogRepositoryTest {
      * Método: Proporciona un PingLog válido y una ruta de archivo incorrecta, y asegúrate de que se maneje la excepción correctamente.
      */
     @Test
-    void testSavePingLogInvalidPath() throws InterruptedException {
+    void testSavePingLogInvalidPath() {
         // when
         PingLog mockPingLog = mock(PingLog.class);
         CsvPingLogRepository underTestSpy = spy(new CsvPingLogRepository("FileNotFound", logger));
 
-        // then
-        underTestSpy.savePingLog(mockPingLog);
-
-        // assert
+        // then assert
+        assertThrows(InterruptedException.class, () -> underTestSpy.savePingLog(mockPingLog));
         verify(logger, times(1)).error(eq(CsvPingLogRepository.SAVE_PING_ERROR_MSG), any(FileNotFoundException.class));
     }
 
@@ -98,17 +97,15 @@ class CsvPingLogRepositoryTest {
      * Método: Configura un escenario donde se provoque una excepción de tipo IOException al intentar escribir en el archivo.
      */
     @Test
-    void testSavePingLogIOException() throws IOException, InterruptedException {
+    void testSavePingLogIOException() throws IOException {
         // when
         PingLog mockPingLog = mock(PingLog.class);
         CsvPingLogRepository underTestSpy = spy(new CsvPingLogRepository("test", logger));
 
         doThrow(new IOException()).when(underTestSpy).getFileWriter();
 
-        // then
-        underTestSpy.savePingLog(mockPingLog);
-
-        // assert
+        // then assert
+        assertThrows(InterruptedException.class, () -> underTestSpy.savePingLog(mockPingLog));
         verify(logger, times(1)).error(eq(CsvPingLogRepository.SAVE_PING_ERROR_MSG), any(IOException.class));
     }
 
@@ -119,7 +116,7 @@ class CsvPingLogRepositoryTest {
      */
     @ParameterizedTest
     @MethodSource("statefulBeanToCsvExceptionsProvider")
-    void testSavePingLogStatefulBeanToCsvExceptions(Class<? extends Throwable> clazz) throws IOException, CsvRequiredFieldEmptyException, CsvDataTypeMismatchException, InterruptedException {
+    void testSavePingLogStatefulBeanToCsvExceptions(Class<? extends Throwable> clazz) throws IOException, CsvRequiredFieldEmptyException, CsvDataTypeMismatchException {
         // when
         PingLog mockPingLog = mock(PingLog.class);
         CsvPingLogRepository underTestSpy = spy(new CsvPingLogRepository("test", logger));
@@ -128,10 +125,8 @@ class CsvPingLogRepositoryTest {
         doThrow(clazz).when(sbcMock).write(mockPingLog);
         when(underTestSpy.getStatefulBeanToCsv(cvsFileWriterMock)).thenReturn(sbcMock);
 
-        // then
-        underTestSpy.savePingLog(mockPingLog);
-
         // assert
+        assertThrows(InterruptedException.class, () -> underTestSpy.savePingLog(mockPingLog));
         verify(logger, times(1)).error(eq(CsvPingLogRepository.SAVE_PING_ERROR_MSG), any(clazz));
     }
 
@@ -167,12 +162,8 @@ class CsvPingLogRepositoryTest {
         CsvPingLogRepository underTestSpy = spy(new CsvPingLogRepository("test", logger));
         doThrow(IOException.class).when(underTestSpy).getReader();
 
-        // then
-        List<PingLog> pingLogsResult = underTestSpy.readAll();
-
-        // assert
-        assertTrue(pingLogsResult.isEmpty());
-        verify(logger, times(1)).error(eq(CsvPingLogRepository.PARSE_ERROR), any(IOException.class));
+        // then assert
+        assertThrows(IOException.class, underTestSpy::readAll);
     }
 
     @ParameterizedTest

--- a/src/test/java/com/adieser/conntest/service/ConnTestServiceImplTest.java
+++ b/src/test/java/com/adieser/conntest/service/ConnTestServiceImplTest.java
@@ -32,10 +32,12 @@ import static com.adieser.utils.PingLogUtils.ISP_IP_ADDRESS;
 import static com.adieser.utils.PingLogUtils.LOCAL_IP_ADDRESS;
 import static com.adieser.utils.PingLogUtils.getDefaultPingLog;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -143,7 +145,7 @@ class ConnTestServiceImplTest {
 
     @ParameterizedTest
     @MethodSource("pingLogsProvider")
-    void testGetPings(List<PingLog> pingLogs) {
+    void testGetPings(List<PingLog> pingLogs) throws IOException {
         // when
         ConnTestServiceImpl underTest = new ConnTestServiceImpl(executorService, logger, tracertProvider, pingLogRepository);
         doReturn(pingLogs).when(pingLogRepository).findAllPingLogs();
@@ -155,9 +157,19 @@ class ConnTestServiceImplTest {
         assertPingSessionResponseEntities(pingLogs, pings);
     }
 
+    @Test
+    void testGetPingsIOException() throws IOException {
+        // when
+        ConnTestServiceImpl underTest = new ConnTestServiceImpl(executorService, logger, tracertProvider, pingLogRepository);
+        doThrow(IOException.class).when(pingLogRepository).findAllPingLogs();
+
+        // then assert
+        assertThrows(IOException.class, underTest::getPings);
+    }
+
     @ParameterizedTest
     @MethodSource("pingLogsProvider")
-    void testGetPingsByDateTimeRange(List<PingLog> pingLogs) {
+    void testGetPingsByDateTimeRange(List<PingLog> pingLogs) throws IOException {
         // when
         ConnTestServiceImpl underTest =new ConnTestServiceImpl(executorService, logger, tracertProvider, pingLogRepository);
         doReturn(pingLogs).when(pingLogRepository).findPingLogsByDateTimeRange(START, END);
@@ -172,9 +184,19 @@ class ConnTestServiceImplTest {
         assertPingSessionResponseEntities(pingLogs, pings);
     }
 
+    @Test
+    void testGetPingsByDateTimeRangeIOException() throws IOException {
+        // when
+        ConnTestServiceImpl underTest = new ConnTestServiceImpl(executorService, logger, tracertProvider, pingLogRepository);
+        doThrow(IOException.class).when(pingLogRepository).findPingLogsByDateTimeRange(START, END);
+
+        // then assert
+        assertThrows(IOException.class, () -> underTest.getPingsByDateTimeRange(START,END));
+    }
+
     @ParameterizedTest
     @MethodSource("pingLogsProvider")
-    void testGetPingsByIp(List<PingLog> pingLogs) {
+    void testGetPingsByIp(List<PingLog> pingLogs) throws IOException {
         // when
         ConnTestServiceImpl underTest = new ConnTestServiceImpl(executorService, logger, tracertProvider, pingLogRepository);
         doReturn(pingLogs).when(pingLogRepository).findPingLogByIp(LOCAL_IP_ADDRESS);
@@ -186,9 +208,19 @@ class ConnTestServiceImplTest {
         assertPingSessionResponseEntities(pingLogs, pings);
     }
 
+    @Test
+    void testGetPingsByIpIOException() throws IOException {
+        // when
+        ConnTestServiceImpl underTest = new ConnTestServiceImpl(executorService, logger, tracertProvider, pingLogRepository);
+        doThrow(IOException.class).when(pingLogRepository).findPingLogByIp(LOCAL_IP_ADDRESS);
+
+        // then assert
+        assertThrows(IOException.class, () -> underTest.getPingsByIp(LOCAL_IP_ADDRESS));
+    }
+
     @ParameterizedTest
     @MethodSource("pingLogsProvider")
-    void testGetPingsByDateTimeRangeByIp(List<PingLog> pingLogs) {
+    void testGetPingsByDateTimeRangeByIp(List<PingLog> pingLogs) throws IOException {
         // when
         ConnTestServiceImpl underTest = new ConnTestServiceImpl(executorService, logger, tracertProvider, pingLogRepository);
         doReturn(pingLogs).when(pingLogRepository).findPingLogsByDateTimeRangeByIp(
@@ -209,7 +241,17 @@ class ConnTestServiceImplTest {
     }
 
     @Test
-    void testGetPingsLostAvgByIp() {
+    void testGetPingsByDateTimeRangeByIpIOException() throws IOException {
+        // when
+        ConnTestServiceImpl underTest = new ConnTestServiceImpl(executorService, logger, tracertProvider, pingLogRepository);
+        doThrow(IOException.class).when(pingLogRepository).findPingLogsByDateTimeRangeByIp(START,END,LOCAL_IP_ADDRESS);
+
+        // then assert
+        assertThrows(IOException.class, () -> underTest.getPingsByDateTimeRangeByIp(START,END,LOCAL_IP_ADDRESS));
+    }
+
+    @Test
+    void testGetPingsLostAvgByIp() throws IOException {
         // when
         ConnTestServiceImpl underTest = new ConnTestServiceImpl(executorService, logger, tracertProvider, pingLogRepository);
         BigDecimal avg = new BigDecimal("0.2");
@@ -223,7 +265,17 @@ class ConnTestServiceImplTest {
     }
 
     @Test
-    void testGetPingsLostAvgByDateTimeRangeByIp() {
+    void testGetPingsLostAvgByIpIOException() throws IOException {
+        // when
+        ConnTestServiceImpl underTest = new ConnTestServiceImpl(executorService, logger, tracertProvider, pingLogRepository);
+        doThrow(IOException.class).when(pingLogRepository).findLostPingLogsAvgByIP(LOCAL_IP_ADDRESS);
+
+        // then assert
+        assertThrows(IOException.class, () -> underTest.getPingsLostAvgByIp(LOCAL_IP_ADDRESS));
+    }
+
+    @Test
+    void testGetPingsLostAvgByDateTimeRangeByIp() throws IOException {
         // when
         ConnTestServiceImpl underTest = new ConnTestServiceImpl(executorService, logger, tracertProvider, pingLogRepository);
         BigDecimal avg = new BigDecimal("0.2");
@@ -242,6 +294,20 @@ class ConnTestServiceImplTest {
 
         // assert
         assertEquals(avg, resultAvg);
+    }
+
+    @Test
+    void testGetPingsLostAvgByDateTimeRangeByIpIOException() throws IOException {
+        // when
+        ConnTestServiceImpl underTest = new ConnTestServiceImpl(executorService, logger, tracertProvider, pingLogRepository);
+        doThrow(IOException.class).when(pingLogRepository).findLostPingLogsAvgByDateTimeRangeByIp(START,
+                END,
+                LOCAL_IP_ADDRESS);
+
+        // then assert
+        assertThrows(IOException.class, () -> underTest.getPingsLostAvgByDateTimeRangeByIp(START,
+                END,
+                LOCAL_IP_ADDRESS));
     }
 
     @Test

--- a/src/test/java/com/adieser/integration/contest/controllers/ConnTestControllerIntegrationTest.java
+++ b/src/test/java/com/adieser/integration/contest/controllers/ConnTestControllerIntegrationTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -32,6 +33,8 @@ import static com.adieser.utils.PingLogUtils.DEFAULT_PING_TIME;
 import static com.adieser.utils.PingLogUtils.LOCAL_IP_ADDRESS;
 import static com.adieser.utils.PingLogUtils.getDefaultPingLog;
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -125,6 +128,18 @@ class ConnTestControllerIntegrationTest {
         verify(connTestService, times(1)).getPings();
     }
 
+    @Test
+    void testGetPingsIOException() throws Exception {
+        // when
+        when(connTestService.getPings()).thenThrow(IOException.class);
+        MockHttpServletRequestBuilder requestBuilder = get("/pings");
+
+        // then assert
+        mockMvc.perform(requestBuilder)
+                .andExpect(status().is5xxServerError())
+                .andExpect(content().string("Internal Server Error"));
+    }
+
     @ParameterizedTest
     @MethodSource("responseProvider")
     void getPingsByDateTimeRange(PingSessionExtract pings) throws Exception {
@@ -144,6 +159,20 @@ class ConnTestControllerIntegrationTest {
         verify(connTestService, times(1)).getPingsByDateTimeRange(START, END);
     }
 
+    @Test
+    void testGetPingsByDateTimeRangeIOException() throws Exception {
+        // when
+        when(connTestService.getPingsByDateTimeRange(any(), any())).thenThrow(IOException.class);
+        MockHttpServletRequestBuilder requestBuilder = get("/pings/{start}/{end}",
+                START.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+                END.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+
+        // then assert
+        mockMvc.perform(requestBuilder)
+                .andExpect(status().is5xxServerError())
+                .andExpect(content().string("Internal Server Error"));
+    }
+
     @ParameterizedTest
     @MethodSource("responseProvider")
     void getPingsByIp(PingSessionExtract pings) throws Exception {
@@ -159,6 +188,18 @@ class ConnTestControllerIntegrationTest {
             AssertHATEOASLinks(resultActions, pings.getPingLogs().get(0));
 
         verify(connTestService, times(1)).getPingsByIp(LOCAL_IP_ADDRESS);
+    }
+
+    @Test
+    void testGetPingsByIpIOException() throws Exception {
+        // when
+        when(connTestService.getPingsByIp(LOCAL_IP_ADDRESS)).thenThrow(IOException.class);
+        MockHttpServletRequestBuilder requestBuilder = get("/pings/{ipAddress}", LOCAL_IP_ADDRESS);
+
+        // then assert
+        mockMvc.perform(requestBuilder)
+                .andExpect(status().is5xxServerError())
+                .andExpect(content().string("Internal Server Error"));
     }
 
     @ParameterizedTest
@@ -182,6 +223,21 @@ class ConnTestControllerIntegrationTest {
     }
 
     @Test
+    void testGetPingsByDateTimeRangeByIpIOException() throws Exception {
+        // when
+        when(connTestService.getPingsByDateTimeRangeByIp(any(), any(), anyString())).thenThrow(IOException.class);
+        MockHttpServletRequestBuilder requestBuilder = get("/pings/{ipAddress}/{start}/{end}",
+                LOCAL_IP_ADDRESS,
+                START.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+                END.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+
+        // then assert
+        mockMvc.perform(requestBuilder)
+                .andExpect(status().is5xxServerError())
+                .andExpect(content().string("Internal Server Error"));
+    }
+
+    @Test
     void getPingsLostAvgByIp() throws Exception {
         // when
         when(connTestService.getPingsLostAvgByIp(LOCAL_IP_ADDRESS))
@@ -202,6 +258,18 @@ class ConnTestControllerIntegrationTest {
 
         assertAverage(resultActions);
         verify(connTestService, times(1)).getPingsLostAvgByIp(LOCAL_IP_ADDRESS);
+    }
+
+    @Test
+    void testGetPingsLostAvgByIpIOException() throws Exception {
+        // when
+        when(connTestService.getPingsLostAvgByIp(LOCAL_IP_ADDRESS)).thenThrow(IOException.class);
+        MockHttpServletRequestBuilder requestBuilder = get("/pings/{ipAddress}/avg", LOCAL_IP_ADDRESS);
+
+        // then assert
+        mockMvc.perform(requestBuilder)
+                .andExpect(status().is5xxServerError())
+                .andExpect(content().string("Internal Server Error"));
     }
 
     @Test
@@ -229,6 +297,21 @@ class ConnTestControllerIntegrationTest {
 
         verify(connTestService, times(1))
                 .getPingsLostAvgByDateTimeRangeByIp(START, END, LOCAL_IP_ADDRESS);
+    }
+
+    @Test
+    void testGetPingsLostAvgByDateTimeRangeByIp() throws Exception {
+        // when
+        when(connTestService.getPingsLostAvgByDateTimeRangeByIp(any(), any(), anyString())).thenThrow(IOException.class);
+        MockHttpServletRequestBuilder requestBuilder = get("/pings/{ipAddress}/avg/{start}/{end}",
+                LOCAL_IP_ADDRESS,
+                START.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+                END.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+
+        // then assert
+        mockMvc.perform(requestBuilder)
+                .andExpect(status().is5xxServerError())
+                .andExpect(content().string("Internal Server Error"));
     }
 
     private ResultActions performRequestAndBasicAssertPingLogControllerResponse(MockHttpServletRequestBuilder requestBuilder,

--- a/src/test/java/com/adieser/integration/contest/exceptions/handlers/GlobalExceptionHandlerIntegrationTest.java
+++ b/src/test/java/com/adieser/integration/contest/exceptions/handlers/GlobalExceptionHandlerIntegrationTest.java
@@ -1,0 +1,39 @@
+package com.adieser.integration.contest.exceptions.handlers;
+
+import com.adieser.conntest.ConntestApplication;
+import com.adieser.conntest.exceptions.handlers.GlobalExceptionHandler;
+import com.adieser.utils.ExceptionHandlerTestController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+//@WebMvcTest(ExceptionHandlerTestController.class)
+@SpringBootTest(classes = ConntestApplication.class)
+@ContextConfiguration(classes = {ConntestApplication.class, ExceptionHandlerTestController.class, GlobalExceptionHandler.class})
+@AutoConfigureMockMvc
+class GlobalExceptionHandlerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void testHandleIOException() throws Exception {
+        mockMvc.perform(get("/exceptionHandlerTest/simulateIOException"))
+                .andExpect(status().is5xxServerError())
+                .andExpect(content().string("Internal Server Error"));
+    }
+
+    @Test
+    void testHandleMethodArgumentTypeMismatchException() throws Exception {
+        mockMvc.perform(get("/exceptionHandlerTest/simulateMethodArgumentTypeMismatchException"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("Bad Request"));
+    }
+}

--- a/src/test/java/com/adieser/utils/ExceptionHandlerTestController.java
+++ b/src/test/java/com/adieser/utils/ExceptionHandlerTestController.java
@@ -1,0 +1,25 @@
+package com.adieser.utils;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+
+@RestController
+@RequestMapping("/exceptionHandlerTest")
+public class ExceptionHandlerTestController {
+
+    @GetMapping("/simulateIOException")
+    public String simulateIOException() throws IOException {
+        throw mock(IOException.class);
+    }
+
+    @GetMapping("/simulateMethodArgumentTypeMismatchException")
+    public String simulateMethodArgumentTypeMismatchException() {
+        throw mock(MethodArgumentTypeMismatchException.class);
+    }
+}


### PR DESCRIPTION
## Overview
The IOException due to missing pingLogs directory is now sent upstream instead of being caught and logged

## Changes
- send IOException upstream
- handle the new exception where required
- fix readAllIOException UT
- fix testSavePingLogInvalidPath UT
- fix testSavePingLogIOException UT
- fix testSavePingLogStatefulBeanToCsvExceptions UT