### PR TITLE
CON-52 Create a new endpoint to reset the pinglog file

### DIFF
--- a/src/main/java/com/adieser/conntest/models/CsvPingLogRepository.java
+++ b/src/main/java/com/adieser/conntest/models/CsvPingLogRepository.java
@@ -35,6 +35,7 @@ import java.util.stream.Stream;
  */
 public class CsvPingLogRepository implements PingLogRepository {
     public static final String SAVE_PING_ERROR_MSG = "Save Ping error";
+    public static final String CLEAN_PINGLOG_FILE_MSG = "Clear pinglog file error";
     public static final String PING_LOG_NAME = "ping.log";
     private final String path;
 
@@ -47,7 +48,7 @@ public class CsvPingLogRepository implements PingLogRepository {
 
     @Override
     public void savePingLog(PingLog pingLog) throws InterruptedException {
-        try (Writer writer  = getFileWriter()) {
+        try (Writer writer  = getFileWriter(true)) {
             CSVWriter csvWriter = getCsvWriter(writer);
             StatefulBeanToCsv<PingLog> sbc = getStatefulBeanToCsv(csvWriter);
 
@@ -58,8 +59,8 @@ public class CsvPingLogRepository implements PingLogRepository {
         }
     }
 
-    FileWriter getFileWriter() throws IOException {
-        return new FileWriter(path + "/" + PING_LOG_NAME, true);
+    FileWriter getFileWriter(boolean append) throws IOException {
+        return new FileWriter(path + "/" + PING_LOG_NAME, append);
     }
 
     CSVWriter getCsvWriter(Writer writer) {
@@ -131,6 +132,17 @@ public class CsvPingLogRepository implements PingLogRepository {
                     BigDecimal.valueOf(pingLogsInDateTimeRange.size()),
                     2,
                     RoundingMode.CEILING);
+    }
+
+    @Override
+    public void clearPingLogFile() throws InterruptedException {
+        try (Writer writer  = getFileWriter(false)) {
+            writer.write("");
+            writer.flush();
+        } catch (IOException e) {
+            logger.error(CLEAN_PINGLOG_FILE_MSG, e);
+            throw new InterruptedException(CLEAN_PINGLOG_FILE_MSG);
+        }
     }
 
     /**

--- a/src/main/java/com/adieser/conntest/models/PingLogRepository.java
+++ b/src/main/java/com/adieser/conntest/models/PingLogRepository.java
@@ -65,4 +65,8 @@ public interface PingLogRepository {
      */
     BigDecimal findLostPingLogsAvgByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException;
 
+    /**
+     * Clear all pings from the pinglog file
+     */
+    void clearPingLogFile() throws InterruptedException;
 }

--- a/src/main/java/com/adieser/conntest/service/ConnTestService.java
+++ b/src/main/java/com/adieser/conntest/service/ConnTestService.java
@@ -78,4 +78,9 @@ public interface ConnTestService {
      * @return list of IP addresses
      */
     List<String> getIpAddressesFromActiveTests();
+
+    /**
+     * Remove all the entries from the current pinglog file
+     */
+    void clearPingLogFile() throws InterruptedException;
 }

--- a/src/main/java/com/adieser/conntest/service/ConnTestServiceImpl.java
+++ b/src/main/java/com/adieser/conntest/service/ConnTestServiceImpl.java
@@ -132,6 +132,11 @@ public class ConnTestServiceImpl implements ConnTestService {
                 .toList();
     }
 
+    @Override
+    public void clearPingLogFile() throws InterruptedException {
+        pingLogRepository.clearPingLogFile();
+    }
+
     /**
      * Create the ping session results formatted as {@link PingSessionExtract}
      * @param pingLogs List of ping sessions results

--- a/src/main/java/com/adieser/conntest/utils/HATEOASLinkRelValueTemplates.java
+++ b/src/main/java/com/adieser/conntest/utils/HATEOASLinkRelValueTemplates.java
@@ -11,4 +11,5 @@ public class HATEOASLinkRelValueTemplates {
     public static final String GET_30_MINS_NEIGHBORHOOD_BY_IP = "get30MinsNeighborhoodByIP-%s";
     public static final String GET_LOST_AVG_BY_IP = "getLostAvgByIP-%s";
     public static final String GET_30_MINS_NEIGHBORHOOD_LOST_AVG_BY_IP = "get30MinsNeighborhoodLostAvgByIP-%s";
+    public static final String CLEAR_PINGLOG_FILE = "clearPinglogFile";
 }

--- a/src/test/java/com/adieser/conntest/service/ConnTestServiceImplTest.java
+++ b/src/test/java/com/adieser/conntest/service/ConnTestServiceImplTest.java
@@ -422,6 +422,18 @@ class ConnTestServiceImplTest {
         assertEquals(expected, testResult);
     }
 
+    @Test
+    void testClearPinglogFile() throws InterruptedException {
+        // when
+        ConnTestServiceImpl underTest = new ConnTestServiceImpl(executorService, logger, tracertProvider, pingLogRepository);
+
+        // then
+        underTest.clearPingLogFile();
+
+        // assert
+        verify(pingLogRepository, times(1)).clearPingLogFile();
+    }
+
     static Stream<Boolean> areTestsRunningProvider() {
         return Stream.of(
                 true,

--- a/src/test/java/com/adieser/integration/contest/models/CsvPingLogRepositoryIntegrationTest.java
+++ b/src/test/java/com/adieser/integration/contest/models/CsvPingLogRepositoryIntegrationTest.java
@@ -183,6 +183,14 @@ class CsvPingLogRepositoryIntegrationTest{
             assertEquals(BigDecimal.ZERO, lostPingLogsAvgByIP, "Wrong average");
     }
 
+    @Test
+    void clearPingLogFile_Success() throws Exception {
+        writePingLog();
+        csvPingLogRepository.clearPingLogFile();
+
+        assertEquals(0, readPingLog().size(), "Failed to clear ping log file");
+    }
+
     /**
      * Create the directories and ping.log file
      */


### PR DESCRIPTION
## Overview
This task adds a new endpoint to remove all the pinglog entries from the pinglog file. This endpoint aims to aid the UI to be able to provide the user with a tool to immediately start a new pinglog file from scratch

## Changes
- add method to clear all the logs in the pingLog file
- add clearPingLogFile HATEOAS link to stopTestSession response