### PR TITLE
CON-59 Get max and slowest ping for a given IP

### DIFF
--- a/src/main/java/com/adieser/conntest/controllers/ConnTestController.java
+++ b/src/main/java/com/adieser/conntest/controllers/ConnTestController.java
@@ -262,8 +262,40 @@ public class ConnTestController {
         return new ResponseEntity<>(lostPings, httpStatus);
     }
 
+    /**
+     * Retrieves the PingLog entries with the highest and lowest latency (pingTime) for a given IP address.
+     * This endpoint returns a PingSessionExtract object containing two PingLog entries:
+     * one with the maximum pingTime and another with the minimum pingTime. The results
+     * are filtered based on the provided IP address.
+     *
+     * @param ipAddress The IP address used to filter the PingLog entries. This parameter is required.
+     * @return A ResponseEntity containing a PingSessionExtract object with the max and min PingLog entries.
+     *         Returns HTTP 200 OK if PingLog entries are found, or HTTP 204 No Content if no entries are found.
+     * @throws IOException If there's an error while processing the request or accessing the data.
+     *
+     * @apiNote This endpoint produces JSON output.
+     *
+     * @see PingSessionExtract
+     */
+    @ApiResponse(responseCode = "200", description = "a pinglog with max pingTime and the pingLog with lowest pingTime.")
+    @GetMapping(value = "/pings/{ipAddress}/max-min", produces = {"application/json"})
+    @Operation(summary = "Get the pinglog with the highest latency and the pinglog with lowest latency.")
+    public ResponseEntity<PingSessionExtract> getMaxMinPingLog(
+            @Parameter(
+                    description = "IP address used to filter the results",
+                    required = true)
+            @PathVariable String ipAddress
+    ) throws IOException {
+        HttpStatus httpStatus = HttpStatus.OK;
+        PingSessionExtract maxMinPingLog = connTestService.getMaxMinPingLog(ipAddress);
 
+        if(maxMinPingLog.getPingLogs().isEmpty())
+            httpStatus = HttpStatus.NO_CONTENT;
+        else
+            addHATEOASLinksForPingLogsReturningEndpoints(maxMinPingLog);
 
+        return new ResponseEntity<>(maxMinPingLog, httpStatus);
+    }
 
     /**
      * Get the average of lost pings within a list of pings filtered by IP

--- a/src/main/java/com/adieser/conntest/models/CsvPingLogRepository.java
+++ b/src/main/java/com/adieser/conntest/models/CsvPingLogRepository.java
@@ -20,6 +20,8 @@ import java.math.RoundingMode;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -110,6 +112,28 @@ public class CsvPingLogRepository implements PingLogRepository {
     public List<PingLog> findLostPingsByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException {
         return getLostPingLogsStream(getPingLogsByDateTimeRangeByIpStream(readAll().stream(), start, end, ipAddress))
                 .toList();
+    }
+
+    @Override
+    public List<PingLog> findMaxMinPingLog(String ipAddress) throws IOException {
+
+        PingLog lowestLatency = getPingLogsByIpStream(readAll().stream(), ipAddress)
+                .min(Comparator.comparingLong(PingLog::getPingTime))
+                .orElse(null);
+
+        // If one of the pingLogs is null, it means both will (the file is empty). Therefore, it returns and empty list
+        if(lowestLatency == null)
+            return List.of();
+
+        PingLog highestLatency = getPingLogsByIpStream(readAll().stream(), ipAddress)
+                .max(Comparator.comparingLong(PingLog::getPingTime))
+                .orElse(null);
+
+        List<PingLog> highestLowest = new ArrayList<>();
+        highestLowest.add(lowestLatency);
+        highestLowest.add(highestLatency);
+
+        return highestLowest;
     }
 
     @Override

--- a/src/main/java/com/adieser/conntest/models/PingLogRepository.java
+++ b/src/main/java/com/adieser/conntest/models/PingLogRepository.java
@@ -100,4 +100,11 @@ public interface PingLogRepository {
      * @see PingLog
      */
     List<PingLog> findLostPingsByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException;
+
+    /**
+     * Retrieve the lowest latency pinglog and the highest latency pinglog
+     * @param ipAddress IP address use to filter the results
+     * @return List of pings
+     */
+    List<PingLog> findMaxMinPingLog(String ipAddress) throws IOException;
 }

--- a/src/main/java/com/adieser/conntest/service/ConnTestService.java
+++ b/src/main/java/com/adieser/conntest/service/ConnTestService.java
@@ -57,9 +57,20 @@ public interface ConnTestService {
      */
     PingSessionExtract getPingsByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException;
 
-
+    /**
+     * Retrieve all the lost ping logs
+     * @param ipAddress IP address use to filter the results
+     * @return List of ping results and metadata {@link PingSessionExtract}
+     */
     PingSessionExtract getLostPingsByIp(String ipAddress) throws IOException;
 
+    /**
+     * Retrieve all the lost ping logs within a datetime range
+     * @param start start date and time of the range
+     * @param end end date in the range
+     * @param ipAddress IP address use to filter the results
+     * @return List of ping results and metadata {@link PingSessionExtract}
+     */
     PingSessionExtract getLostPingsByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException;
 
     /**
@@ -88,4 +99,11 @@ public interface ConnTestService {
      * Remove all the entries from the current pinglog file
      */
     void clearPingLogFile() throws InterruptedException;
+
+    /**
+     * Retrieve the lowest latency pinglog and the highest latency pinglog
+     * @param ipAddress IP address use to filter the results
+     * @return List of ping results and metadata {@link PingSessionExtract}
+     */
+    PingSessionExtract getMaxMinPingLog(String ipAddress) throws IOException;
 }

--- a/src/main/java/com/adieser/conntest/service/ConnTestServiceImpl.java
+++ b/src/main/java/com/adieser/conntest/service/ConnTestServiceImpl.java
@@ -164,6 +164,14 @@ public class ConnTestServiceImpl implements ConnTestService {
         pingLogRepository.clearPingLogFile();
     }
 
+    @Override
+    public PingSessionExtract getMaxMinPingLog(String ipAddress) throws IOException {
+        PingSessionExtract response = createBasicResponse(pingLogRepository.findMaxMinPingLog(ipAddress));
+        response.setIpAddress(ipAddress);
+
+        return response;
+    }
+
     /**
      * Create the ping session results formatted as {@link PingSessionExtract}
      * @param pingLogs List of ping sessions results

--- a/src/test/java/com/adieser/conntest/models/CsvPingLogRepositoryTest.java
+++ b/src/test/java/com/adieser/conntest/models/CsvPingLogRepositoryTest.java
@@ -169,7 +169,7 @@ class CsvPingLogRepositoryTest {
 
     @ParameterizedTest
     @MethodSource("getPingLogsByDateTimeRangeByIpStreamProvider")
-    void testGetPingLogsByDateTimeRangeByIp(LocalDateTime pingDate,
+    void testGetPingLogsByDateTimeRangeByIpStream(LocalDateTime pingDate,
                                             LocalDateTime start,
                                             LocalDateTime end,
                                             String ipAddress,
@@ -195,7 +195,7 @@ class CsvPingLogRepositoryTest {
 
     @ParameterizedTest
     @MethodSource("getLostPingLogsStreamProvider")
-    void testGetLostPingLogsStreamSuccess(long pingTime, boolean pingFound){
+    void testGetLostPingLogsStream(long pingTime, boolean pingFound){
         // when
         CsvPingLogRepository underTest = new CsvPingLogRepository("test", logger);
         PingLog pingLog = getDefaultPingLog();
@@ -262,6 +262,8 @@ class CsvPingLogRepositoryTest {
         assertEquals(CsvPingLogRepository.CLEAN_PINGLOG_FILE_MSG, exception.getMessage());
         verify(logger).error(eq(CsvPingLogRepository.CLEAN_PINGLOG_FILE_MSG), any(IOException.class));
     }
+
+
 
     static Stream<PingLog> successPingLogProvider() {
         return Stream.of(

--- a/src/test/java/com/adieser/conntest/service/ConnTestServiceImplTest.java
+++ b/src/test/java/com/adieser/conntest/service/ConnTestServiceImplTest.java
@@ -509,6 +509,26 @@ class ConnTestServiceImplTest {
         verify(pingLogRepository, times(1)).clearPingLogFile();
     }
 
+    @Test
+    void testGetMaxMinPingLog() throws IOException {
+        // when
+        ConnTestServiceImpl underTest =
+                new ConnTestServiceImpl(executorService, logger, tracertProvider, pingLogRepository, pingUtils);
+        doReturn(
+                List.of(getDefaultPingLog(),
+                        getDefaultPingLog()))
+                .when(pingLogRepository).findMaxMinPingLog(LOCAL_IP_ADDRESS);
+
+        // then
+        PingSessionExtract pings = underTest.getMaxMinPingLog(LOCAL_IP_ADDRESS);
+
+        // assert
+        assertEquals(DEFAULT_PING_TIME, pings.getPingLogs().get(0).getPingTime());
+        assertEquals(DEFAULT_PING_TIME, pings.getPingLogs().get(1).getPingTime());
+        assertEquals(2, pings.getAmountOfPings());
+        assertEquals(LOCAL_IP_ADDRESS, pings.getIpAddress());
+    }
+
     static Stream<Boolean> areTestsRunningProvider() {
         return Stream.of(
                 true,


### PR DESCRIPTION
## Overview
This PR adds a new endpoint to retrieve a list of 2 pingolgs. One with the highest latency and the other one with the lowest latency. If there is no Pinglog, the endpoint will return an empty list

## Changes
- add new endpoint max-min
- add new service getMaxMinPingLog
- add new repository read method findMaxMinPingLog