### PR TITLE
CON-63 Calculate the average latency for a given IP in a datetime range

### DIFF
--- a/src/main/java/com/adieser/conntest/controllers/ConnTestController.java
+++ b/src/main/java/com/adieser/conntest/controllers/ConnTestController.java
@@ -357,8 +357,8 @@ public class ConnTestController {
                 .build();
 
         averageResult.add(
-                linkTo(methodOn(ConnTestController.class).getPingsByDateTimeRangeByIp(ipAddress, start, end))
-                        .withRel(HATEOASLinkRelValueTemplates.GET_30_MINS_NEIGHBORHOOD_BY_IP.formatted(ipAddress))
+                linkTo(methodOn(ConnTestController.class).getLostPingsByDateTimeRangeByIp(ipAddress, start, end))
+                        .withRel(HATEOASLinkRelValueTemplates.GET_LOST_BY_IP_BETWEEN.formatted(ipAddress,start,end))
         );
 
         return new ResponseEntity<>(
@@ -384,6 +384,46 @@ public class ConnTestController {
         averageResult.add(
                 linkTo(methodOn(ConnTestController.class).getPingsByIp(ipAddress))
                         .withRel(HATEOASLinkRelValueTemplates.GET_BY_IP.formatted(ipAddress))
+        );
+
+        return new ResponseEntity<>(
+                averageResult,
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * Get the average of lost pings within a datetime range filtered by IP
+     * @param ipAddress IP address used to filter the results
+     * @param start Start date and time of the range
+     * @param end End date in the range
+     * @return If successful it returns a number representing the average of lost pings
+     */
+    @ApiResponse(responseCode = "200", description = "a number representing the average of lost pings.")
+    @GetMapping(value = "/pings/{ipAddress}/avg-latency/{start}/{end}", produces = {"application/json"})
+    @Operation(summary = "Get the average of lost pings within a datetime range filtered by IP")
+    public ResponseEntity<AverageResponse> getAvgLatencyByDateTimeRangeByIp(
+            @Parameter(
+                    description = "IP address used to filter the results",
+                    required = true)
+            @PathVariable String ipAddress,
+            @Parameter(
+                    description = "Start date and time of the range",
+                    required = true)
+            @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime start,
+            @Parameter(
+                    description = "End date in the range",
+                    required = true)
+            @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime end) throws IOException {
+
+        AverageResponse averageResult = AverageResponse.builder()
+                .ipAddress(ipAddress)
+                .average(connTestService.getAvgLatencyByDateTimeRangeByIp(start, end, ipAddress))
+                .build();
+
+        averageResult.add(
+                linkTo(methodOn(ConnTestController.class).getPingsByDateTimeRangeByIp(ipAddress, start, end))
+                        .withRel(HATEOASLinkRelValueTemplates.GET_BY_IP_BETWEEN.formatted(ipAddress, start, end))
         );
 
         return new ResponseEntity<>(

--- a/src/main/java/com/adieser/conntest/models/CsvPingLogRepository.java
+++ b/src/main/java/com/adieser/conntest/models/CsvPingLogRepository.java
@@ -119,6 +119,18 @@ public class CsvPingLogRepository implements PingLogRepository {
     }
 
     @Override
+    public BigDecimal findAvgLatencyByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException {
+        double averagePingTime = getPingLogsByDateTimeRangeByIpStream(readAll().stream(), start, end, ipAddress)
+                .map(PingLog::getPingTime)
+                .filter(time -> time != -1)
+                .mapToLong(Long::longValue)
+                .average()
+                .orElse(0.0);
+
+        return BigDecimal.valueOf(averagePingTime).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    @Override
     public BigDecimal findLostPingLogsAvgByIP(String ipAddress) throws IOException {
 
         List<PingLog> pingLogsByIp = getPingLogsByIpStream(readAll().stream(), ipAddress).toList();

--- a/src/main/java/com/adieser/conntest/models/PingLogRepository.java
+++ b/src/main/java/com/adieser/conntest/models/PingLogRepository.java
@@ -114,4 +114,14 @@ public interface PingLogRepository {
      * @return average of latency pings
      */
     BigDecimal findAvgLatencyByIp(String ipAddress) throws IOException;
+
+    /**
+     * Calculate and retrieve the average of latency pings within a list of pings within a datetime range filtered
+     * by IP address and not-lost pings
+     * @param start start date and time of the range
+     * @param end end date in the range
+     * @param ipAddress IP address use to filter the results
+     * @return average of latency pings
+     */
+    BigDecimal findAvgLatencyByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException;
 }

--- a/src/main/java/com/adieser/conntest/service/ConnTestService.java
+++ b/src/main/java/com/adieser/conntest/service/ConnTestService.java
@@ -113,4 +113,13 @@ public interface ConnTestService {
      * @return average latency of all the ping logs
      */
     BigDecimal getAvgLatencyByIp(String ipAddress) throws IOException;
+
+    /**
+     * Get the average latency of all the ping logs within a datetime range filtered by IP
+     * @param start start date and time of the range
+     * @param end end date in the range
+     * @param ipAddress IP address use to filter the results
+     * @return average latency of all the ping logs
+     */
+    BigDecimal getAvgLatencyByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException;
 }

--- a/src/main/java/com/adieser/conntest/service/ConnTestServiceImpl.java
+++ b/src/main/java/com/adieser/conntest/service/ConnTestServiceImpl.java
@@ -158,6 +158,11 @@ public class ConnTestServiceImpl implements ConnTestService {
     }
 
     @Override
+    public BigDecimal getAvgLatencyByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException {
+        return pingLogRepository.findAvgLatencyByDateTimeRangeByIp(start, end, ipAddress);
+    }
+
+    @Override
     public List<String> getIpAddressesFromActiveTests(){
         return tests.stream()
                 .map(ConnTest::getIpAddress)

--- a/src/main/java/com/adieser/conntest/utils/HATEOASLinkRelValueTemplates.java
+++ b/src/main/java/com/adieser/conntest/utils/HATEOASLinkRelValueTemplates.java
@@ -7,6 +7,8 @@ public class HATEOASLinkRelValueTemplates {
     public static final String START_TEST_SESSION = "startTestSession";
     public static final String STOP_TEST_SESSION = "stopTestSession";
     public static final String GET_BY_IP = "getByIP-%s";
+    public static final String GET_BY_IP_BETWEEN = "getByIPBetween-%s|%s / %s";
+    public static final String GET_LOST_BY_IP_BETWEEN = "getLostByIPBetween-%s|%s / %s";
     public static final String GET_30_MINS_NEIGHBORHOOD = "get30MinsNeighborhood";
     public static final String GET_30_MINS_NEIGHBORHOOD_BY_IP = "get30MinsNeighborhoodByIP-%s";
     public static final String GET_LOST_AVG_BY_IP = "getLostAvgByIP-%s";

--- a/src/test/java/com/adieser/conntest/models/CsvPingLogRepositoryTest.java
+++ b/src/test/java/com/adieser/conntest/models/CsvPingLogRepositoryTest.java
@@ -36,7 +36,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -62,7 +61,7 @@ class CsvPingLogRepositoryTest {
         underTestSpy.savePingLog(pingLog);
 
         // assert
-        verify(fileWriterServiceMock, times(1)).submit(pingLog);
+        verify(fileWriterServiceMock).submit(pingLog);
     }
 
     /**
@@ -228,6 +227,31 @@ class CsvPingLogRepositoryTest {
         BigDecimal result = underTestSpy.findAvgLatencyByIp(LOCAL_IP_ADDRESS);
 
         // Assert
+        assertEquals(expectedAvg, result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("findAvgLatencyByIpPingLogProvider")
+    void testFindAvgLatencyByDateTimeRangeByIp(List<PingLog> pingLogs,
+                                               BigDecimal expectedAvg) throws IOException {
+
+        // When
+        LocalDateTime start = mock(LocalDateTime.class);
+        LocalDateTime end = mock(LocalDateTime.class);
+
+        doReturn(mock(List.class))
+                .when(underTestSpy)
+                .readAll();
+
+        doReturn(pingLogs.stream())
+                .when(underTestSpy)
+                .getPingLogsByDateTimeRangeByIpStream(any(), eq(start), eq(end), eq(LOCAL_IP_ADDRESS));
+
+        // Then
+        BigDecimal result = underTestSpy.findAvgLatencyByDateTimeRangeByIp(start, end, LOCAL_IP_ADDRESS);
+
+        // Assert
+        verify(underTestSpy).getPingLogsByDateTimeRangeByIpStream(any(),  eq(start), eq(end), eq(LOCAL_IP_ADDRESS));
         assertEquals(expectedAvg, result);
     }
 

--- a/src/test/java/com/adieser/conntest/service/ConnTestServiceImplTest.java
+++ b/src/test/java/com/adieser/conntest/service/ConnTestServiceImplTest.java
@@ -42,7 +42,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -79,7 +78,7 @@ class ConnTestServiceImplTest {
         // assert
         localAndISPIpAddresses.add(CLOUD_IP_ADDRESS);
         underTest.tests.forEach(mockConnTest ->
-                verify(underTest, times(1)).testCustomIps(localAndISPIpAddresses)
+                verify(underTest).testCustomIps(localAndISPIpAddresses)
         );
     }
 
@@ -115,12 +114,12 @@ class ConnTestServiceImplTest {
 
         // assert
         if(areTestRunning) {
-            verify(logger, times(1)).warn("Tests are already running (IP {})", ip1);
-            verify(logger, times(1)).warn("Tests are already running (IP {})", ip2);
-            verify(logger, times(1)).warn("Tests are already running (IP {})", ip3);
+            verify(logger).warn("Tests are already running (IP {})", ip1);
+            verify(logger).warn("Tests are already running (IP {})", ip2);
+            verify(logger).warn("Tests are already running (IP {})", ip3);
         } else{
             underTest.tests.forEach(mockConnTest ->
-                    verify(mockConnTest, times(1)).startPingSession()
+                    verify(mockConnTest).startPingSession()
             );
         }
     }
@@ -141,10 +140,10 @@ class ConnTestServiceImplTest {
 
         // assert
         if(!areTestRunning)
-            verify(logger, times(1)).warn("No tests to stop");
+            verify(logger).warn("No tests to stop");
         else{
             mockConnTests.forEach(mockConnTest ->
-                    verify(mockConnTest, times(1)).stopPingSession()
+                    verify(mockConnTest).stopPingSession()
             );
             assertTrue(underTest.tests.isEmpty());
         }
@@ -440,7 +439,7 @@ class ConnTestServiceImplTest {
         underTest.getLocalAndISPIpAddresses();
 
         // assert
-        verify(logger, times(1)).error(eq("Traceroute error"), any(IOException.class));
+        verify(logger).error(eq("Traceroute error"), any(IOException.class));
     }
 
     @Test
@@ -471,7 +470,7 @@ class ConnTestServiceImplTest {
         Optional<BufferedReader> reader = underTest.executeTracert();
 
         // assert
-        verify(tracertProvider, times(1)).executeTracert();
+        verify(tracertProvider).executeTracert();
         assertEquals(mockReader, reader);
     }
 
@@ -506,7 +505,7 @@ class ConnTestServiceImplTest {
         underTest.clearPingLogFile();
 
         // assert
-        verify(pingLogRepository, times(1)).clearPingLogFile();
+        verify(pingLogRepository).clearPingLogFile();
     }
 
     @Test
@@ -541,6 +540,30 @@ class ConnTestServiceImplTest {
         BigDecimal resultAvg = underTest.getAvgLatencyByIp(LOCAL_IP_ADDRESS);
 
         // assert
+        assertEquals(avg, resultAvg);
+    }
+
+    @Test
+    void testGetAvgLatencyByDateTimeRangeByIp() throws IOException {
+        // when
+        ConnTestServiceImpl underTest =
+                new ConnTestServiceImpl(executorService, logger, tracertProvider, pingLogRepository, pingUtils);
+        BigDecimal avg = new BigDecimal("0.2");
+        doReturn(avg).when(pingLogRepository).findAvgLatencyByDateTimeRangeByIp(
+                START,
+                END,
+                LOCAL_IP_ADDRESS
+        );
+
+        // then
+        BigDecimal resultAvg = underTest.getAvgLatencyByDateTimeRangeByIp(
+                START,
+                END,
+                LOCAL_IP_ADDRESS
+        );
+
+        // assert
+        verify(pingLogRepository).findAvgLatencyByDateTimeRangeByIp(START, END, LOCAL_IP_ADDRESS);
         assertEquals(avg, resultAvg);
     }
 


### PR DESCRIPTION
## Overview
The main goal of this PR is to create an endpoint to calculate the average latency for a given IP. It takes into account a datetime range.
It also fix a few bugs around HATEOAS links

## Changes
- add new endpoint for getting the average latency by date range by IP
- fix HATEOAS links