### PR TITLE
CON-64 Get max and slowest ping for a given IP in a datetime range

### DIFF
--- a/src/main/java/com/adieser/conntest/controllers/ConnTestController.java
+++ b/src/main/java/com/adieser/conntest/controllers/ConnTestController.java
@@ -298,6 +298,51 @@ public class ConnTestController {
     }
 
     /**
+     * Retrieves the PingLog entries with the highest and lowest latency (pingTime) for a given IP address
+     * within a specified datetime range. This endpoint returns a PingSessionExtract object containing
+     * two PingLog entries: one with the maximum pingTime and another with the minimum pingTime. The results
+     * are filtered based on the provided IP address and datetime range.
+     *
+     * @param ipAddress The IP address used to filter the PingLog entries. This parameter is required.
+     * @param start The start date and time of the range. This parameter is required.
+     * @param end The end date and time of the range. This parameter is required.
+     * @return A ResponseEntity containing a PingSessionExtract object with the max and min PingLog entries.
+     *         Returns HTTP 200 OK if PingLog entries are found, or HTTP 204 No Content if no entries are found.
+     * @throws IOException If there's an error while processing the request or accessing the data.
+     *
+     * @apiNote This endpoint produces JSON output.
+     *
+     * @see PingSessionExtract
+     */
+    @ApiResponse(responseCode = "200", description = "a pinglog with max pingTime and the pingLog with lowest pingTime.")
+    @GetMapping(value = "/pings/{ipAddress}/max-min/{start}/{end}", produces = {"application/json"})
+    @Operation(summary = "Get the pinglog with the highest latency and the pinglog with lowest latency within a datetime range.")
+    public ResponseEntity<PingSessionExtract> getMaxMinPingLogByDateTimeRangeByIp(
+            @Parameter(
+                    description = "IP address used to filter the results",
+                    required = true)
+            @PathVariable String ipAddress,
+            @Parameter(
+                    description = "Start date and time of the range",
+                    required = true)
+            @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime start,
+            @Parameter(
+                    description = "End date in the range",
+                    required = true)
+            @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime end
+    ) throws IOException {
+        HttpStatus httpStatus = HttpStatus.OK;
+        PingSessionExtract maxMinPingLog = connTestService.getMaxMinPingLogByDateTimeRangeByIp(start, end, ipAddress);
+
+        if(maxMinPingLog.getPingLogs().isEmpty())
+            httpStatus = HttpStatus.NO_CONTENT;
+        else
+            addHATEOASLinksForPingLogsReturningEndpoints(maxMinPingLog);
+
+        return new ResponseEntity<>(maxMinPingLog, httpStatus);
+    }
+
+    /**
      * Get the average of lost pings within a list of pings filtered by IP
      * @param ipAddress IP address used to filter the results
      * @return If successful it returns a number representing the average of lost pings

--- a/src/main/java/com/adieser/conntest/models/PingLogRepository.java
+++ b/src/main/java/com/adieser/conntest/models/PingLogRepository.java
@@ -106,7 +106,16 @@ public interface PingLogRepository {
      * @param ipAddress IP address use to filter the results
      * @return List of pings
      */
-    List<PingLog> findMaxMinPingLog(String ipAddress) throws IOException;
+    List<PingLog> findMaxMinPingLogOfAll(String ipAddress) throws IOException;
+
+    /**
+     * Retrieve the lowest latency pinglog and the highest latency pinglog within a datetime range
+     * @param start start date and time of the range
+     * @param end end date in the range
+     * @param ipAddress IP address use to filter the results
+     * @return List of pings
+     */
+    List<PingLog> findMaxMinPingLogByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException;
 
     /**
      * Calculate and retrieve the average of latency pings within a list of pings filtered by IP address

--- a/src/main/java/com/adieser/conntest/service/ConnTestService.java
+++ b/src/main/java/com/adieser/conntest/service/ConnTestService.java
@@ -108,6 +108,15 @@ public interface ConnTestService {
     PingSessionExtract getMaxMinPingLog(String ipAddress) throws IOException;
 
     /**
+     * Retrieve the lowest latency pinglog and the highest latency pinglog within a datetime range
+     * @param start start date and time of the range
+     * @param end end date in the range
+     * @param ipAddress IP address use to filter the results
+     * @return List of ping results and metadata {@link PingSessionExtract}
+     */
+    PingSessionExtract getMaxMinPingLogByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException;
+
+    /**
      * Get the average latency of all the ping logs filtered by IP
      * @param ipAddress IP address use to filter the results
      * @return average latency of all the ping logs

--- a/src/main/java/com/adieser/conntest/service/ConnTestServiceImpl.java
+++ b/src/main/java/com/adieser/conntest/service/ConnTestServiceImpl.java
@@ -176,7 +176,15 @@ public class ConnTestServiceImpl implements ConnTestService {
 
     @Override
     public PingSessionExtract getMaxMinPingLog(String ipAddress) throws IOException {
-        PingSessionExtract response = createBasicResponse(pingLogRepository.findMaxMinPingLog(ipAddress));
+        PingSessionExtract response = createBasicResponse(pingLogRepository.findMaxMinPingLogOfAll(ipAddress));
+        response.setIpAddress(ipAddress);
+
+        return response;
+    }
+
+    @Override
+    public PingSessionExtract getMaxMinPingLogByDateTimeRangeByIp(LocalDateTime start, LocalDateTime end, String ipAddress) throws IOException {
+        PingSessionExtract response = createBasicResponse(pingLogRepository.findMaxMinPingLogByDateTimeRangeByIp(start, end, ipAddress));
         response.setIpAddress(ipAddress);
 
         return response;

--- a/src/test/java/com/adieser/conntest/service/ConnTestServiceImplTest.java
+++ b/src/test/java/com/adieser/conntest/service/ConnTestServiceImplTest.java
@@ -516,10 +516,34 @@ class ConnTestServiceImplTest {
         doReturn(
                 List.of(getDefaultPingLog(),
                         getDefaultPingLog()))
-                .when(pingLogRepository).findMaxMinPingLog(LOCAL_IP_ADDRESS);
+                .when(pingLogRepository).findMaxMinPingLogOfAll(LOCAL_IP_ADDRESS);
 
         // then
         PingSessionExtract pings = underTest.getMaxMinPingLog(LOCAL_IP_ADDRESS);
+
+        // assert
+        assertEquals(DEFAULT_PING_TIME, pings.getPingLogs().get(0).getPingTime());
+        assertEquals(DEFAULT_PING_TIME, pings.getPingLogs().get(1).getPingTime());
+        assertEquals(2, pings.getAmountOfPings());
+        assertEquals(LOCAL_IP_ADDRESS, pings.getIpAddress());
+    }
+
+    @Test
+    void testGetMaxMinPingLogByDateTimeRangeByIp() throws IOException {
+        // when
+        ConnTestServiceImpl underTest =
+                new ConnTestServiceImpl(executorService, logger, tracertProvider, pingLogRepository, pingUtils);
+        doReturn(
+                List.of(getDefaultPingLog(),
+                        getDefaultPingLog()))
+                .when(pingLogRepository).findMaxMinPingLogByDateTimeRangeByIp(START,
+                        END,
+                        LOCAL_IP_ADDRESS);
+
+        // then
+        PingSessionExtract pings = underTest.getMaxMinPingLogByDateTimeRangeByIp(START,
+                END,
+                LOCAL_IP_ADDRESS);
 
         // assert
         assertEquals(DEFAULT_PING_TIME, pings.getPingLogs().get(0).getPingTime());


### PR DESCRIPTION
## Overview
The PR adds a new endpoint for getting 2 pings within a date range: the one with the lowest latency and the one with the highest latency. 

## Changes
- add new endpoint
- add new service method
- add new repository method